### PR TITLE
:sparkles: add init refresh for Kit-managed project files

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,7 +353,8 @@ scaffold files such as `.envrc`, `.coderabbit.yaml`, and the pull request
 template are skipped by default. Use `kit init --refresh --force` to overwrite
 refreshable generated documentation and known registry rulesets, or
 `kit init --refresh --file=.envrc --force` to overwrite one existing
-Kit-managed file explicitly.
+Kit-managed file explicitly. Use `kit init --refresh --dry-run --diff` to
+preview the managed-file changes without writing them.
 
 ## 🗂️ Structured Engine: Artifact Pipeline
 

--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ kit init
 # later, after the repo has real contents, refresh durable project-level docs
 kit prompt project refresh
 
+# refresh Kit-managed scaffold docs/files to the current Kit defaults
+kit init --refresh
+
 # optionally capture research first
 kit brainstorm my-feature
 
@@ -341,6 +344,16 @@ Instruction scaffold versions:
 - new repos default to `v2`
 - existing repos keep their current model unless `--version` explicitly switches them
 - switching models is a repo-wide change and requires `--force`
+
+`kit init --refresh` is the consolidated refresh command for existing Kit
+projects. It creates missing Kit-managed files, migrates known generated v1
+instruction files to the v2 thin docs model, refreshes generated instruction
+support docs, and imports missing known registry rulesets. Existing local
+scaffold files such as `.envrc`, `.coderabbit.yaml`, and the pull request
+template are skipped by default. Use `kit init --refresh --force` to overwrite
+refreshable generated documentation and known registry rulesets, or
+`kit init --refresh --file=.envrc --force` to overwrite one existing
+Kit-managed file explicitly.
 
 ## 🗂️ Structured Engine: Artifact Pipeline
 

--- a/docs/CONSTITUTION.md
+++ b/docs/CONSTITUTION.md
@@ -142,6 +142,13 @@ all decisions.
    - Include context (file paths, feature names)
    - Fail fast — don't continue with partial state
 
+4. **Code File Size**
+   - Applies only to implementation/source code files
+   - Prefer code files around 300 lines or less when splitting improves clarity and ownership
+   - Treat the limit as guidance, not a mandate to fragment cohesive code; justify larger code files when the reason is not obvious
+   - Excluded: documentation files, all `docs/**`, all `.kit/**`, and `.kit.yaml`
+   - Do not split or rewrite docs, generated state, or Kit config artifacts solely because they exceed 300 lines
+
 ---
 
 ## CHANGE CLASSIFICATION
@@ -318,6 +325,16 @@ The semantic refresh flow for updating durable project-level truth after a repos
 - Updates `docs/CONSTITUTION.md` only when durable project-wide rules, vocabulary, constraints, or conventions changed
 - Uses `kit reconcile --all` for structural contract drift instead of duplicating reconciliation
 - Remains advisory and docs-only; it does not rerun `kit init` or block lifecycle commands
+
+### Init Refresh
+
+The structural refresh flow for updating Kit-managed project files to the current Kit defaults:
+
+- Invoked with `kit init --refresh`
+- Creates missing Kit-managed scaffold files, instruction docs, support docs, and known registry rulesets
+- Merges or appends missing Kit-managed documentation sections by default instead of overwriting project-specific content
+- Migrates old verbose repository instruction files to the v2 thin ToC/RLM model when they still match known generated templates
+- Uses `kit init --refresh --force` for generated documentation/ruleset overwrites and `kit init --refresh --file=<path> --force` for per-file scaffold overwrites such as `.envrc`
 
 ### Map
 

--- a/docs/CONSTITUTION.md
+++ b/docs/CONSTITUTION.md
@@ -334,6 +334,7 @@ The structural refresh flow for updating Kit-managed project files to the curren
 - Creates missing Kit-managed scaffold files, instruction docs, support docs, and known registry rulesets
 - Merges or appends missing Kit-managed documentation sections by default instead of overwriting project-specific content
 - Migrates old verbose repository instruction files to the v2 thin ToC/RLM model when they still match known generated templates
+- Uses `kit init --refresh --dry-run --diff` to preview managed-file changes without writing them
 - Uses `kit init --refresh --force` for generated documentation/ruleset overwrites and `kit init --refresh --file=<path> --force` for per-file scaffold overwrites such as `.envrc`
 
 ### Map

--- a/docs/agents/GUARDRAILS.md
+++ b/docs/agents/GUARDRAILS.md
@@ -26,6 +26,8 @@
 
 - Remove dead code, unused exports, and public surfaces that are not strictly necessary
 - If a symbol is only used locally, reduce its visibility instead of keeping it exported
+- Keep implementation/source code files around 300 lines or less when splitting improves clarity
+- Do not apply the 300-line guideline to documentation files, `docs/**`, `.kit/**`, or `.kit.yaml`
 
 ## Safety
 

--- a/docs/references/rules/github-pr-delivery.md
+++ b/docs/references/rules/github-pr-delivery.md
@@ -89,6 +89,7 @@ Include:
 - If branch `GH-123` already exists locally or remotely, inspect it before continuing.
 - Do not reuse an existing branch if it contains unrelated work.
 - If a PR already exists for `GH-123`, update it instead of duplicating.
+- Before updating an existing PR, check active PRs for the current branch and confirm the active directory, branch, remote, PR head, and PR base match the intended issue branch and repository.
 - If issue, branch, and PR state disagree, stop and summarize the mismatch.
 
 ### Branch Workflow
@@ -103,7 +104,11 @@ Include:
 ```bash
 git checkout -b GH-123 origin/$BASE_BRANCH
 test "$(git rev-parse --abbrev-ref HEAD)" = "GH-123" || { echo "ABORT: wrong branch"; exit 1; }
+gh pr list --head GH-123 --state all --json number,url,state,isDraft,headRefName,baseRefName,assignees
 ```
+
+- Before editing after any thread resume or user redirect, repeat branch and PR recon for the active directory because another thread may have moved the work forward.
+- If the active branch or PR lookup does not match the intended `GH-123` branch and repository, stop and ask before editing.
 
 ### Implementation Workflow
 
@@ -176,10 +181,16 @@ Commit body must include:
 ### Push And PR Workflow
 
 ```bash
+git status --short --branch
+git remote -v
+test "$(git rev-parse --abbrev-ref HEAD)" = "GH-123" || { echo "ABORT: wrong branch"; exit 1; }
+gh pr list --head GH-123 --state all --json number,url,state,isDraft,headRefName,baseRefName,assignees
 git push -u origin GH-123
 git log -1 --format='%an <%ae> | %cn <%ce>'
 ```
 
+- Immediately before pushing, confirm the active directory, current branch, upstream remote, and active PR state still match the intended issue branch and repository.
+- If an existing PR is found for `GH-123`, update that PR; do not create a duplicate.
 - Push only after committing.
 - Verify remote-side author and committer are the human user.
 - On push rejection, such as a stale base, follow `safety-guardrails` failure handling.
@@ -239,12 +250,14 @@ Include:
 - Confirm issue resolution searched existing open issues before creating a new issue.
 - Confirm branch name exactly matches the issue number in `GH-123` form.
 - Confirm checkout is on the issue-number branch before editing.
+- Confirm active PRs for the current branch were checked before editing after any thread resume or user redirect.
 - Confirm each changed file was reviewed before explicit staging.
 - Confirm no secrets or local config were staged.
 - Confirm author and committer identity were inspected before commit and are the human user.
 - Confirm staged diff was reviewed before commit.
 - Confirm commit title and body follow the required format.
 - Confirm branch was pushed only after commit.
+- Confirm active directory, branch, remote, and PR state were rechecked immediately before pushing.
 - Confirm PR was created with the repository template when present.
 - Confirm PR assignee is the human user.
 - Confirm PR is ready for review and not draft unless explicitly requested otherwise.

--- a/docs/references/rules/github-pr-delivery.md
+++ b/docs/references/rules/github-pr-delivery.md
@@ -207,6 +207,10 @@ git log -1 --format='%an <%ae> | %cn <%ce>'
 - Create the PR using `.github/pull_request_template.md` when present.
 - Preserve PR template headings.
 - Author the PR body in the user's name; do not add agent self-attribution.
+- Prefix the PR title with a descriptive gitmoji code that reflects the primary work.
+- Prefix each concrete bullet in the PR `Description` section with a descriptive gitmoji code that reflects that bullet's work.
+- Use gitmoji codes that are aligned with the work being described, such as `:sparkles:` for feature work, `:bug:` for fixes, `:memo:` for documentation, `:white_check_mark:` for tests, `:recycle:` for refactors, `:green_heart:` for CI, `:wrench:` for tooling, `:dizzy:` for refresh or migration flows, and `:notebook:` for constitution, guide, or reference updates.
+- Keep PR headings from the template unchanged; add gitmoji prefixes to title and description content, not to template headings.
 - Assign the PR to the human user.
 - Use `Closes #123` when the PR fully resolves the issue.
 - Use `Refs #123` when the PR only partially addresses the issue.
@@ -271,6 +275,7 @@ Include:
 - Confirm branch was pushed only after commit.
 - Confirm active directory, branch, remote, and PR state were rechecked immediately before pushing.
 - Confirm PR was created with the repository template when present.
+- Confirm PR title and `Description` bullets use descriptive gitmoji prefixes while preserving template headings.
 - Confirm PR assignee is the human user.
 - Confirm PR is ready for review and not draft unless explicitly requested otherwise.
 - Confirm PR and CI state were observed before final reporting.
@@ -305,6 +310,18 @@ Commit title:
 
 ```text
 docs(GH-125): :memo: document PR workflow
+```
+
+PR title and description formatting:
+
+```text
+PR Title: :sparkles: add invitation workflow
+
+## Description
+
+- :sparkles: Adds the invitation creation workflow.
+- :white_check_mark: Adds focused coverage for invitation validation.
+- :memo: Documents the operator-facing invitation behavior.
 ```
 
 Post-PR checks:

--- a/docs/references/rules/github-pr-delivery.md
+++ b/docs/references/rules/github-pr-delivery.md
@@ -1,7 +1,7 @@
 ---
 kind: ruleset
 slug: github-pr-delivery
-description: Sequences issue, branch, commit, push, draft PR, and post-PR checks after PR workflow consent.
+description: Sequences issue, branch, commit, push, ready PR, and post-PR checks after PR workflow consent.
 status: active
 applies_to:
   - git
@@ -187,18 +187,21 @@ git log -1 --format='%an <%ae> | %cn <%ce>'
 - Create the PR using `.github/pull_request_template.md` when present.
 - Preserve PR template headings.
 - Author the PR body in the user's name; do not add agent self-attribution.
+- Assign the PR to the human user.
 - Use `Closes #123` when the PR fully resolves the issue.
 - Use `Refs #123` when the PR only partially addresses the issue.
-- Default to a draft PR unless explicitly told otherwise.
+- Create the PR ready for review, not as a draft, unless the user explicitly asks for a draft PR.
 
 ### Post-PR Verification
 
 ```bash
-gh pr view --json number,url,author,state
+gh pr view --json number,url,author,state,isDraft,assignees
 gh pr checks
 ```
 
 - Confirm GitHub shows the human user as commit author and committer.
+- Confirm the PR is assigned to the human user.
+- Confirm the PR is ready for review and not draft, unless the user explicitly asked for a draft PR.
 - Do not claim CI passed unless checks were observed passing.
 - If checks are pending, failing, unavailable, or not run, report that exact state.
 
@@ -243,6 +246,8 @@ Include:
 - Confirm commit title and body follow the required format.
 - Confirm branch was pushed only after commit.
 - Confirm PR was created with the repository template when present.
+- Confirm PR assignee is the human user.
+- Confirm PR is ready for review and not draft unless explicitly requested otherwise.
 - Confirm PR and CI state were observed before final reporting.
 
 ## Examples
@@ -277,6 +282,6 @@ docs(GH-125): :memo: document PR workflow
 Post-PR checks:
 
 ```bash
-gh pr view --json number,url,author,state
+gh pr view --json number,url,author,state,isDraft,assignees
 gh pr checks
 ```

--- a/docs/references/rules/github-pr-delivery.md
+++ b/docs/references/rules/github-pr-delivery.md
@@ -96,17 +96,26 @@ Include:
 
 - Branch name is the GitHub issue number only, exact form: `GH-123`.
 - Do not add a slug, suffix, or description.
-- Create from the correct protected base branch; never commit directly to base.
 - Create or switch branches in the existing project directory.
 - Do not create or use git worktrees for PR delivery.
-- Confirm checkout before editing:
+- Before branching, refresh the base from the remote. Fetch only. Never pull, merge, or checkout the base:
+
+```bash
+git fetch origin "$BASE_BRANCH"
+git rev-list --left-right --count "$BASE_BRANCH...origin/$BASE_BRANCH" 2>/dev/null || true
+```
+
+- Create the new branch from the freshly fetched remote base, never from a local copy:
 
 ```bash
 git checkout -b GH-123 origin/$BASE_BRANCH
 test "$(git rev-parse --abbrev-ref HEAD)" = "GH-123" || { echo "ABORT: wrong branch"; exit 1; }
+test "$(git rev-parse HEAD)" = "$(git rev-parse origin/$BASE_BRANCH)" || { echo "ABORT: branch base not at remote head"; exit 1; }
 gh pr list --head GH-123 --state all --json number,url,state,isDraft,headRefName,baseRefName,assignees
 ```
 
+- Never commit directly to the base branch, which is protected under `safety-guardrails`.
+- If `git fetch` fails due to offline state, auth, remote errors, or any other reason, stop per `safety-guardrails` failure handling. Do not branch off a base that could not be refreshed.
 - Before editing after any thread resume or user redirect, repeat branch and PR recon for the active directory because another thread may have moved the work forward.
 - If the active branch or PR lookup does not match the intended `GH-123` branch and repository, stop and ask before editing.
 
@@ -249,6 +258,9 @@ Include:
 - Confirm base branch was discovered instead of assumed.
 - Confirm issue resolution searched existing open issues before creating a new issue.
 - Confirm branch name exactly matches the issue number in `GH-123` form.
+- Confirm `git fetch origin "$BASE_BRANCH"` refreshed the remote base before branch creation.
+- Confirm the branch was created from `origin/$BASE_BRANCH`, not local `$BASE_BRANCH`.
+- Confirm branch HEAD equals `origin/$BASE_BRANCH` immediately after branch creation.
 - Confirm checkout is on the issue-number branch before editing.
 - Confirm active PRs for the current branch were checked before editing after any thread resume or user redirect.
 - Confirm each changed file was reviewed before explicit staging.
@@ -274,8 +286,11 @@ gh issue list --state open --search "invitation workflow in:title" --json number
 Create and confirm the issue-number branch:
 
 ```bash
+git fetch origin "$BASE_BRANCH"
+git rev-list --left-right --count "$BASE_BRANCH...origin/$BASE_BRANCH" 2>/dev/null || true
 git checkout -b GH-123 origin/$BASE_BRANCH
 test "$(git rev-parse --abbrev-ref HEAD)" = "GH-123" || { echo "ABORT: wrong branch"; exit 1; }
+test "$(git rev-parse HEAD)" = "$(git rev-parse origin/$BASE_BRANCH)" || { echo "ABORT: branch base not at remote head"; exit 1; }
 ```
 
 Review, stage, and inspect:

--- a/docs/references/rules/safety-guardrails.md
+++ b/docs/references/rules/safety-guardrails.md
@@ -56,9 +56,16 @@ pwd
 git status --short --branch
 git remote -v
 git rev-parse --abbrev-ref HEAD
+CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+gh pr list --head "$CURRENT_BRANCH" --state all --json number,url,state,isDraft,headRefName,baseRefName,assignees
 ```
 
 - Identify current branch, default/base branch, and repository owner/name.
+- Identify active pull requests for the current branch before editing, committing, pushing, or mutating any PR.
+- Confirm the active directory, branch, remote, and PR head branch match the intended work lane.
+- Repeat this recon after thread resumes, user redirects, branch changes, or any sign that another thread may have moved the work forward.
+- If the active branch, remote, or PR state does not match the expected issue branch or repository, stop and summarize the mismatch before editing or pushing.
+- If `gh` is unavailable, use an approved GitHub connector for the active PR lookup; if neither is available, report that the active PR check could not run before mutating.
 - Do not overwrite, revert, or mix unrelated user changes.
 - If unrelated dirty files exist, leave them alone.
 - If dirty files overlap the requested work, stop and explain the conflict before editing.
@@ -140,6 +147,8 @@ On any failure, including lint, test, push rejection, template error, auth error
 
 - Confirm `pwd`, `git status --short --branch`, `git remote -v`, and `git rev-parse --abbrev-ref HEAD` were run and shown.
 - Confirm current branch, default/base branch, and repository owner/name were identified.
+- Confirm active PRs for the current branch were checked, or that an unavailable PR lookup was explicitly reported before mutation.
+- Confirm the active directory, branch, remote, and PR state matched the intended work lane before editing, committing, pushing, or mutating a PR.
 - Confirm protected or assumed-protected branches were not written to.
 - Confirm overlapping dirty files caused a stop before editing.
 - Confirm author and committer identity were inspected before any commit.
@@ -155,6 +164,8 @@ pwd
 git status --short --branch
 git remote -v
 git rev-parse --abbrev-ref HEAD
+CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+gh pr list --head "$CURRENT_BRANCH" --state all --json number,url,state,isDraft,headRefName,baseRefName,assignees
 ```
 
 Git identity inspection:

--- a/docs/specs/0000_INIT_PROJECT.md
+++ b/docs/specs/0000_INIT_PROJECT.md
@@ -472,6 +472,10 @@ CLI flags always override `.kit.yaml`.
 - make the first visible next step: paste the copied prompt into the agent to draft `docs/CONSTITUTION.md`
 - support `--output-only` to print the raw prompt to stdout instead of copying it
 - support `--copy` to also copy the prompt when `--output-only` is set
+- support `--refresh` as the existing-project structural refresh mode for Kit-managed files
+- support `--refresh --dry-run --diff` to print planned Kit-managed file changes without writing them
+- support `--refresh --force` for generated documentation and ruleset overwrites
+- support `--refresh --file=<path> --force` for targeted per-file scaffold overwrites
 
 ---
 
@@ -953,7 +957,7 @@ Findings:
 Verification:
 
 - run `kit check --all` for project-wide reconciliation or `kit check <feature>` for feature-scoped reconciliation
-- run `kit init` when reconcile reports init scaffold drift, then review the scaffold-file diff
+- run `kit init --refresh --dry-run --diff` when reconcile reports init scaffold drift, then apply the intended refresh with `kit init --refresh`
 - run the maintenance command `kit rollup` when reconciled changes affect
   `PROJECT_PROGRESS_SUMMARY.md`
 

--- a/internal/templates/instruction_templates_standards.go
+++ b/internal/templates/instruction_templates_standards.go
@@ -88,9 +88,10 @@ A change is done when all applicable conditions are met for its track.
 - Use descriptive names for variables, functions, classes, parameters, methods
 - Keep functions focused on a single responsibility
 - Prefer explicit error handling over silent failures
-- Soft file size limit: 200 lines
-- Hard file size limit: 300 lines (exceptions require justification)
-- Split files that exceed limits
+- Code file size guideline: keep implementation/source files around 300 lines or less when splitting improves clarity
+- Treat 200 lines as a review trigger for code files, not a mandatory split point
+- Do not apply the 300-line guideline to documentation files, any ` + "`docs/**`" + ` files, ` + "`.kit/**`" + `, or ` + "`.kit.yaml`" + `
+- Justify larger code files when the reason is not obvious
 
 ---
 
@@ -108,7 +109,7 @@ A change is done when all applicable conditions are met for its track.
 
 ## Package Structure Guidelines
 
-- Keep files under 300 lines when possible
+- Keep code files under 300 lines when possible; documentation files, ` + "`docs/**`" + `, ` + "`.kit/**`" + `, and ` + "`.kit.yaml`" + ` are out of scope
 - One file per resource type, domain object, or logical grouping
 - Place shared/common types in a dedicated ` + "`types.go`" + `
 - Place service definitions, constructors, and shared options in main package files

--- a/internal/templates/instruction_templates_v2.go
+++ b/internal/templates/instruction_templates_v2.go
@@ -294,6 +294,8 @@ const agentsGuardrails = `# Guardrails
 
 - Remove dead code, unused exports, and public surfaces that are not strictly necessary
 - If a symbol is only used locally, reduce its visibility instead of keeping it exported
+- Keep implementation/source code files around 300 lines or less when splitting improves clarity
+- Do not apply the 300-line guideline to documentation files, ` + "`docs/**`" + `, ` + "`.kit/**`" + `, or ` + "`.kit.yaml`" + `
 
 ## Safety
 

--- a/internal/templates/templates.go
+++ b/internal/templates/templates.go
@@ -40,6 +40,16 @@ const Constitution = `# CONSTITUTION
 
 <!-- TODO: define invariant rules that must never be violated -->
 
+### Kit-Managed Baseline Rules
+
+<!-- BEGIN KIT-MANAGED BASELINE RULES -->
+- Treat ` + "`docs/CONSTITUTION.md`" + ` as the canonical project contract.
+- Keep ` + "`AGENTS.md`" + `, ` + "`CLAUDE.md`" + `, and ` + "`.github/copilot-instructions.md`" + ` aligned with the repo-local docs tree.
+- Prefer implementation/source code files around 300 lines or less when splitting improves clarity and ownership.
+- Do not apply the code-file size guideline to documentation files, all ` + "`docs/**`" + `, all ` + "`.kit/**`" + `, or ` + "`.kit.yaml`" + `.
+- Do not split or rewrite docs, generated state, or Kit config artifacts solely because they exceed 300 lines.
+<!-- END KIT-MANAGED BASELINE RULES -->
+
 ## CHANGE CLASSIFICATION
 
 <!-- all work falls into one of two tracks — classify before acting -->

--- a/internal/templates/templates_test.go
+++ b/internal/templates/templates_test.go
@@ -175,6 +175,63 @@ func TestInstructionTemplatesIncludeDocAndExportHygiene(t *testing.T) {
 	}
 }
 
+func TestInstructionTemplatesScopeCodeFileSizeGuidance(t *testing.T) {
+	legacyChecks := []string{
+		"Code file size guideline",
+		"implementation/source files around 300 lines",
+		"documentation files",
+		"`docs/**`",
+		"`.kit/**`",
+		"`.kit.yaml`",
+	}
+
+	for name, content := range map[string]string{
+		"AGENTS.md":                       LegacyAgentsMD,
+		"CLAUDE.md":                       LegacyClaudeMD,
+		".github/copilot-instructions.md": LegacyCopilotInstructionsMD,
+	} {
+		for _, check := range legacyChecks {
+			if !strings.Contains(content, check) {
+				t.Fatalf("expected %s to contain %q", name, check)
+			}
+		}
+		for _, stale := range []string{
+			"Hard file size limit: 300 lines",
+			"Keep files under 300 lines when possible",
+		} {
+			if strings.Contains(content, stale) {
+				t.Fatalf("expected %s not to contain stale unscoped guidance %q", name, stale)
+			}
+		}
+	}
+
+	guardrails := fileContentByPath(
+		InstructionSupportFiles(config.InstructionScaffoldVersionTOC),
+		"docs/agents/GUARDRAILS.md",
+	)
+	for _, check := range []string{
+		"implementation/source code files around 300 lines",
+		"documentation files, `docs/**`, `.kit/**`, or `.kit.yaml`",
+	} {
+		if !strings.Contains(guardrails, check) {
+			t.Fatalf("expected GUARDRAILS.md to contain %q", check)
+		}
+	}
+}
+
+func TestConstitutionTemplateIncludesKitManagedBaselineRules(t *testing.T) {
+	for _, check := range []string{
+		"### Kit-Managed Baseline Rules",
+		"BEGIN KIT-MANAGED BASELINE RULES",
+		"Prefer implementation/source code files around 300 lines",
+		"Do not apply the code-file size guideline to documentation files",
+	} {
+		if !strings.Contains(Constitution, check) {
+			t.Fatalf("expected Constitution template to contain %q", check)
+		}
+	}
+}
+
 func TestDefaultInstructionTemplatesGlossRLMAndCopilotFallback(t *testing.T) {
 	for name, content := range map[string]string{
 		"AGENTS.md": AgentsMD,

--- a/pkg/cli/init.go
+++ b/pkg/cli/init.go
@@ -18,6 +18,8 @@ var initCopy bool
 var initOutputOnly bool
 var initRefresh bool
 var initForce bool
+var initDryRun bool
+var initDiff bool
 var initRefreshFiles []string
 
 var initCmd = &cobra.Command{
@@ -45,6 +47,8 @@ Modes:
 Flags:
   --output-only:  Output the raw prompt to stdout instead of copying it to the clipboard
   --copy:         Copy prompt to clipboard even with --output-only
+  --dry-run:      Preview --refresh without writing files
+  --diff:         Print planned --refresh changes as a unified diff with --dry-run
   --force:        Overwrite refreshable generated docs during --refresh
   --file:         Limit --refresh to one Kit-managed file; repeat for multiple files`,
 	RunE: runInit,
@@ -54,6 +58,8 @@ func init() {
 	initCmd.Flags().BoolVar(&initCopy, "copy", false, "copy prompt to clipboard even with --output-only")
 	initCmd.Flags().BoolVar(&initOutputOnly, "output-only", false, "output prompt text to stdout instead of copying it to the clipboard")
 	initCmd.Flags().BoolVar(&initRefresh, "refresh", false, "refresh Kit-managed project files instead of creating a new-project prompt")
+	initCmd.Flags().BoolVar(&initDryRun, "dry-run", false, "preview --refresh without writing files")
+	initCmd.Flags().BoolVar(&initDiff, "diff", false, "print planned --refresh changes as a unified diff with --dry-run")
 	initCmd.Flags().BoolVarP(&initForce, "force", "f", false, "overwrite refreshable generated docs during --refresh")
 	initCmd.Flags().StringArrayVar(&initRefreshFiles, "file", nil, "limit --refresh to a Kit-managed file; repeat for multiple files")
 	rootCmd.AddCommand(initCmd)
@@ -62,6 +68,15 @@ func init() {
 func runInit(cmd *cobra.Command, args []string) error {
 	if initForce && !initRefresh {
 		return fmt.Errorf("--force requires --refresh")
+	}
+	if initDryRun && !initRefresh {
+		return fmt.Errorf("--dry-run requires --refresh")
+	}
+	if initDiff && !initRefresh {
+		return fmt.Errorf("--diff requires --refresh")
+	}
+	if initDiff && !initDryRun {
+		return fmt.Errorf("--diff requires --dry-run")
 	}
 	if len(initRefreshFiles) > 0 && !initRefresh {
 		return fmt.Errorf("--file requires --refresh")
@@ -75,6 +90,8 @@ func runInit(cmd *cobra.Command, args []string) error {
 	if initRefresh {
 		return runInitRefresh(cwd, initRefreshOptions{
 			force:      initForce,
+			dryRun:     initDryRun,
+			diff:       initDiff,
 			files:      initRefreshFiles,
 			outputOnly: initOutputOnly,
 		})

--- a/pkg/cli/init.go
+++ b/pkg/cli/init.go
@@ -16,6 +16,9 @@ import (
 
 var initCopy bool
 var initOutputOnly bool
+var initRefresh bool
+var initForce bool
+var initRefreshFiles []string
 
 var initCmd = &cobra.Command{
 	Use:   "init",
@@ -37,23 +40,44 @@ be merged by adding missing required sections.
 
 Modes:
   Default:        Copy the prepared CONSTITUTION.md prompt to the clipboard and show next steps
+  --refresh:      Refresh Kit-managed project files for an existing Kit project
 
 Flags:
   --output-only:  Output the raw prompt to stdout instead of copying it to the clipboard
-  --copy:         Copy prompt to clipboard even with --output-only`,
+  --copy:         Copy prompt to clipboard even with --output-only
+  --force:        Overwrite refreshable generated docs during --refresh
+  --file:         Limit --refresh to one Kit-managed file; repeat for multiple files`,
 	RunE: runInit,
 }
 
 func init() {
 	initCmd.Flags().BoolVar(&initCopy, "copy", false, "copy prompt to clipboard even with --output-only")
 	initCmd.Flags().BoolVar(&initOutputOnly, "output-only", false, "output prompt text to stdout instead of copying it to the clipboard")
+	initCmd.Flags().BoolVar(&initRefresh, "refresh", false, "refresh Kit-managed project files instead of creating a new-project prompt")
+	initCmd.Flags().BoolVarP(&initForce, "force", "f", false, "overwrite refreshable generated docs during --refresh")
+	initCmd.Flags().StringArrayVar(&initRefreshFiles, "file", nil, "limit --refresh to a Kit-managed file; repeat for multiple files")
 	rootCmd.AddCommand(initCmd)
 }
 
 func runInit(cmd *cobra.Command, args []string) error {
+	if initForce && !initRefresh {
+		return fmt.Errorf("--force requires --refresh")
+	}
+	if len(initRefreshFiles) > 0 && !initRefresh {
+		return fmt.Errorf("--file requires --refresh")
+	}
+
 	cwd, err := os.Getwd()
 	if err != nil {
 		return fmt.Errorf("failed to get working directory: %w", err)
+	}
+
+	if initRefresh {
+		return runInitRefresh(cwd, initRefreshOptions{
+			force:      initForce,
+			files:      initRefreshFiles,
+			outputOnly: initOutputOnly,
+		})
 	}
 
 	if !initOutputOnly {

--- a/pkg/cli/init_refresh.go
+++ b/pkg/cli/init_refresh.go
@@ -3,11 +3,13 @@ package cli
 import (
 	"context"
 	"fmt"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
 
 	"github.com/jamesonstone/kit/internal/config"
+	"gopkg.in/yaml.v3"
 )
 
 const constitutionBaselineHeading = "Kit-Managed Baseline Rules"
@@ -24,6 +26,8 @@ const constitutionBaselineSection = `### ` + constitutionBaselineHeading + `
 
 type initRefreshOptions struct {
 	force      bool
+	dryRun     bool
+	diff       bool
 	files      []string
 	outputOnly bool
 }
@@ -57,7 +61,7 @@ func runInitRefresh(projectRoot string, opts initRefreshOptions) error {
 		}
 	}
 
-	cfg, err := initRefreshConfig(projectRoot, opts, targets)
+	cfg, configChange, err := initRefreshConfig(projectRoot, opts, targets)
 	if err != nil {
 		return err
 	}
@@ -67,22 +71,52 @@ func runInitRefresh(projectRoot string, opts initRefreshOptions) error {
 		return err
 	}
 
-	if !opts.outputOnly {
+	if !opts.outputOnly && !opts.dryRun {
 		fmt.Println("🔄 Refreshing Kit-managed project files...")
 	}
 
+	var changes []initRefreshFileChange
+	if configChange != nil {
+		changes = append(changes, *configChange)
+	}
+
 	var stats initRefreshStats
-	if err := refreshInitScaffoldFiles(projectRoot, opts, targets, &stats); err != nil {
+	scaffoldChanges, err := planRefreshInitScaffoldFiles(projectRoot, opts, targets)
+	if err != nil {
 		return err
 	}
-	if err := refreshInitConstitution(projectRoot, cfg, targets, &stats); err != nil {
+	changes = append(changes, scaffoldChanges...)
+	constitutionChange, err := planRefreshInitConstitution(projectRoot, cfg, targets)
+	if err != nil {
 		return err
 	}
-	if err := refreshInitInstructionArtifacts(projectRoot, opts, cfg, targets, &stats); err != nil {
+	if constitutionChange != nil {
+		changes = append(changes, *constitutionChange)
+	}
+	instructionChanges, err := planRefreshInitInstructionArtifacts(projectRoot, opts, cfg, targets)
+	if err != nil {
 		return err
 	}
-	if err := refreshInitRulesets(projectRoot, opts, targets, registry, &stats); err != nil {
+	changes = append(changes, instructionChanges...)
+	rulesetChanges, err := planRefreshInitRulesets(projectRoot, opts, targets, registry)
+	if err != nil {
 		return err
+	}
+	changes = append(changes, rulesetChanges...)
+
+	if opts.dryRun {
+		for _, change := range changes {
+			stats.recordFileChange(change)
+		}
+		printInitRefreshDryRun(changes, stats, opts)
+		return nil
+	}
+
+	for _, change := range changes {
+		if err := applyInitRefreshFileChange(change); err != nil {
+			return err
+		}
+		stats.recordFileChange(change)
 	}
 
 	if !opts.outputOnly {
@@ -98,15 +132,27 @@ func runInitRefresh(projectRoot string, opts initRefreshOptions) error {
 	return nil
 }
 
-func initRefreshConfig(projectRoot string, opts initRefreshOptions, targets map[string]bool) (*config.Config, error) {
+func initRefreshConfig(
+	projectRoot string,
+	opts initRefreshOptions,
+	targets map[string]bool,
+) (*config.Config, *initRefreshFileChange, error) {
 	cfg := defaultInitConfig()
 	configSelected := initRefreshTargetMatches(targets, config.ConfigFileName)
 	shouldTouchConfig := len(targets) == 0 || configSelected
+	path := filepath.Join(projectRoot, config.ConfigFileName)
+	exists := config.Exists(projectRoot)
+	var before string
 
-	if config.Exists(projectRoot) {
+	if exists {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to read %s: %w", config.ConfigFileName, err)
+		}
+		before = string(data)
 		existing, err := config.Load(projectRoot)
 		if err != nil {
-			return nil, fmt.Errorf("failed to load %s: %w", config.ConfigFileName, err)
+			return nil, nil, fmt.Errorf("failed to load %s: %w", config.ConfigFileName, err)
 		}
 		cfg = existing
 	}
@@ -114,28 +160,37 @@ func initRefreshConfig(projectRoot string, opts initRefreshOptions, targets map[
 	if configSelected && opts.force {
 		cfg = defaultInitConfig()
 		cfg.InstructionScaffoldVersion = config.InstructionScaffoldVersionTOC
-		if err := config.Save(projectRoot, cfg); err != nil {
-			return nil, fmt.Errorf("failed to overwrite %s: %w", config.ConfigFileName, err)
+		after, err := marshalInitRefreshConfig(cfg)
+		if err != nil {
+			return nil, nil, err
 		}
-		return cfg, nil
+		result := instructionFileCreated
+		if exists {
+			result = instructionFileUpdated
+		}
+		return cfg, newInitRefreshFileChange(projectRoot, config.ConfigFileName, before, after, result), nil
 	}
 
 	if cfg.InstructionScaffoldVersion != config.InstructionScaffoldVersionTOC {
 		cfg.InstructionScaffoldVersion = config.InstructionScaffoldVersionTOC
 		if shouldTouchConfig {
-			if err := config.Save(projectRoot, cfg); err != nil {
-				return nil, fmt.Errorf("failed to update %s: %w", config.ConfigFileName, err)
+			after, err := marshalInitRefreshConfig(cfg)
+			if err != nil {
+				return nil, nil, err
 			}
+			return cfg, newInitRefreshFileChange(projectRoot, config.ConfigFileName, before, after, instructionFileUpdated), nil
 		}
 	}
 
-	if !config.Exists(projectRoot) && shouldTouchConfig {
-		if err := config.Save(projectRoot, cfg); err != nil {
-			return nil, fmt.Errorf("failed to create %s: %w", config.ConfigFileName, err)
+	if !exists && shouldTouchConfig {
+		after, err := marshalInitRefreshConfig(cfg)
+		if err != nil {
+			return nil, nil, err
 		}
+		return cfg, newInitRefreshFileChange(projectRoot, config.ConfigFileName, before, after, instructionFileCreated), nil
 	}
 
-	return cfg, nil
+	return cfg, nil, nil
 }
 
 func initRefreshKnownTargets(cfg *config.Config, registry []registryRuleset) map[string]bool {
@@ -208,7 +263,11 @@ func initRefreshTargetMatches(targets map[string]bool, relativePath string) bool
 	return ok
 }
 
-func (s *initRefreshStats) recordInstructionResult(result instructionFileWriteResult) {
+func (s *initRefreshStats) recordFileChange(change initRefreshFileChange) {
+	s.recordResult(change.result)
+}
+
+func (s *initRefreshStats) recordResult(result instructionFileWriteResult) {
 	switch result {
 	case instructionFileCreated:
 		s.created++
@@ -219,4 +278,12 @@ func (s *initRefreshStats) recordInstructionResult(result instructionFileWriteRe
 	case instructionFileSkipped:
 		s.skipped++
 	}
+}
+
+func marshalInitRefreshConfig(cfg *config.Config) (string, error) {
+	data, err := yaml.Marshal(cfg)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal config: %w", err)
+	}
+	return string(data), nil
 }

--- a/pkg/cli/init_refresh.go
+++ b/pkg/cli/init_refresh.go
@@ -1,0 +1,222 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/jamesonstone/kit/internal/config"
+)
+
+const constitutionBaselineHeading = "Kit-Managed Baseline Rules"
+
+const constitutionBaselineSection = `### ` + constitutionBaselineHeading + `
+
+<!-- BEGIN KIT-MANAGED BASELINE RULES -->
+- Treat ` + "`docs/CONSTITUTION.md`" + ` as the canonical project contract.
+- Keep ` + "`AGENTS.md`" + `, ` + "`CLAUDE.md`" + `, and ` + "`.github/copilot-instructions.md`" + ` aligned with the repo-local docs tree.
+- Prefer implementation/source code files around 300 lines or less when splitting improves clarity and ownership.
+- Do not apply the code-file size guideline to documentation files, all ` + "`docs/**`" + `, all ` + "`.kit/**`" + `, or ` + "`.kit.yaml`" + `.
+- Do not split or rewrite docs, generated state, or Kit config artifacts solely because they exceed 300 lines.
+<!-- END KIT-MANAGED BASELINE RULES -->`
+
+type initRefreshOptions struct {
+	force      bool
+	files      []string
+	outputOnly bool
+}
+
+type initRefreshStats struct {
+	created int
+	updated int
+	merged  int
+	skipped int
+}
+
+func runInitRefresh(projectRoot string, opts initRefreshOptions) error {
+	targets, err := normalizeInitRefreshTargets(opts.files)
+	if err != nil {
+		return err
+	}
+
+	needsRegistry := len(targets) == 0
+	for target := range targets {
+		if strings.HasPrefix(target, rulesetDirRelPath+"/") {
+			needsRegistry = true
+			break
+		}
+	}
+
+	var registry []registryRuleset
+	if needsRegistry {
+		registry, err = rulesetRegistryFetcher(context.Background())
+		if err != nil {
+			return fmt.Errorf("failed to refresh Kit ruleset registry: %w", err)
+		}
+	}
+
+	cfg, err := initRefreshConfig(projectRoot, opts, targets)
+	if err != nil {
+		return err
+	}
+
+	knownTargets := initRefreshKnownTargets(cfg, registry)
+	if err := validateInitRefreshTargets(targets, knownTargets); err != nil {
+		return err
+	}
+
+	if !opts.outputOnly {
+		fmt.Println("🔄 Refreshing Kit-managed project files...")
+	}
+
+	var stats initRefreshStats
+	if err := refreshInitScaffoldFiles(projectRoot, opts, targets, &stats); err != nil {
+		return err
+	}
+	if err := refreshInitConstitution(projectRoot, cfg, targets, &stats); err != nil {
+		return err
+	}
+	if err := refreshInitInstructionArtifacts(projectRoot, opts, cfg, targets, &stats); err != nil {
+		return err
+	}
+	if err := refreshInitRulesets(projectRoot, opts, targets, registry, &stats); err != nil {
+		return err
+	}
+
+	if !opts.outputOnly {
+		fmt.Println("\n✅ Kit project refresh complete!")
+		fmt.Printf(
+			"   Created: %d, Updated: %d, Merged: %d, Skipped: %d\n",
+			stats.created,
+			stats.updated,
+			stats.merged,
+			stats.skipped,
+		)
+	}
+	return nil
+}
+
+func initRefreshConfig(projectRoot string, opts initRefreshOptions, targets map[string]bool) (*config.Config, error) {
+	cfg := defaultInitConfig()
+	configSelected := initRefreshTargetMatches(targets, config.ConfigFileName)
+	shouldTouchConfig := len(targets) == 0 || configSelected
+
+	if config.Exists(projectRoot) {
+		existing, err := config.Load(projectRoot)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load %s: %w", config.ConfigFileName, err)
+		}
+		cfg = existing
+	}
+
+	if configSelected && opts.force {
+		cfg = defaultInitConfig()
+		cfg.InstructionScaffoldVersion = config.InstructionScaffoldVersionTOC
+		if err := config.Save(projectRoot, cfg); err != nil {
+			return nil, fmt.Errorf("failed to overwrite %s: %w", config.ConfigFileName, err)
+		}
+		return cfg, nil
+	}
+
+	if cfg.InstructionScaffoldVersion != config.InstructionScaffoldVersionTOC {
+		cfg.InstructionScaffoldVersion = config.InstructionScaffoldVersionTOC
+		if shouldTouchConfig {
+			if err := config.Save(projectRoot, cfg); err != nil {
+				return nil, fmt.Errorf("failed to update %s: %w", config.ConfigFileName, err)
+			}
+		}
+	}
+
+	if !config.Exists(projectRoot) && shouldTouchConfig {
+		if err := config.Save(projectRoot, cfg); err != nil {
+			return nil, fmt.Errorf("failed to create %s: %w", config.ConfigFileName, err)
+		}
+	}
+
+	return cfg, nil
+}
+
+func initRefreshKnownTargets(cfg *config.Config, registry []registryRuleset) map[string]bool {
+	known := map[string]bool{
+		config.ConfigFileName:                  true,
+		gitignorePath:                          true,
+		envPath:                                true,
+		envrcPath:                              true,
+		codeRabbitConfigPath:                   true,
+		pullRequestTemplatePath:                true,
+		cfg.ConstitutionPath:                   true,
+		filepath.ToSlash(cfg.ConstitutionPath): true,
+	}
+	for _, relativePath := range instructionArtifactPaths(
+		cfg,
+		instructionFileSelection{},
+		config.InstructionScaffoldVersionTOC,
+		true,
+	) {
+		known[filepath.ToSlash(relativePath)] = true
+	}
+	for _, item := range registry {
+		known[rulesetTarget(item.Slug)] = true
+	}
+	return known
+}
+
+func normalizeInitRefreshTargets(files []string) (map[string]bool, error) {
+	targets := make(map[string]bool, len(files))
+	for _, file := range files {
+		target := strings.TrimSpace(file)
+		if target == "" {
+			return nil, fmt.Errorf("--file target cannot be blank")
+		}
+		if filepath.IsAbs(target) {
+			return nil, fmt.Errorf("--file target %q must be relative to the project root", file)
+		}
+		target = filepath.ToSlash(filepath.Clean(target))
+		target = strings.TrimPrefix(target, "./")
+		if target == "." || strings.HasPrefix(target, "../") {
+			return nil, fmt.Errorf("--file target %q must stay inside the project root", file)
+		}
+		targets[target] = true
+	}
+	return targets, nil
+}
+
+func validateInitRefreshTargets(targets, known map[string]bool) error {
+	if len(targets) == 0 {
+		return nil
+	}
+	var unknown []string
+	for target := range targets {
+		if !known[target] {
+			unknown = append(unknown, target)
+		}
+	}
+	if len(unknown) == 0 {
+		return nil
+	}
+	sort.Strings(unknown)
+	return fmt.Errorf("%s is not a Kit-managed refresh target", strings.Join(unknown, ", "))
+}
+
+func initRefreshTargetMatches(targets map[string]bool, relativePath string) bool {
+	if len(targets) == 0 {
+		return true
+	}
+	_, ok := targets[filepath.ToSlash(relativePath)]
+	return ok
+}
+
+func (s *initRefreshStats) recordInstructionResult(result instructionFileWriteResult) {
+	switch result {
+	case instructionFileCreated:
+		s.created++
+	case instructionFileUpdated:
+		s.updated++
+	case instructionFileMerged:
+		s.merged++
+	case instructionFileSkipped:
+		s.skipped++
+	}
+}

--- a/pkg/cli/init_refresh_change.go
+++ b/pkg/cli/init_refresh_change.go
@@ -1,0 +1,43 @@
+package cli
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/jamesonstone/kit/internal/document"
+)
+
+type initRefreshFileChange struct {
+	relativePath string
+	absolutePath string
+	before       string
+	after        string
+	result       instructionFileWriteResult
+}
+
+func newInitRefreshFileChange(
+	projectRoot string,
+	relativePath string,
+	before string,
+	after string,
+	result instructionFileWriteResult,
+) *initRefreshFileChange {
+	relativePath = filepath.ToSlash(relativePath)
+	return &initRefreshFileChange{
+		relativePath: relativePath,
+		absolutePath: filepath.Join(projectRoot, filepath.FromSlash(relativePath)),
+		before:       before,
+		after:        after,
+		result:       result,
+	}
+}
+
+func applyInitRefreshFileChange(change initRefreshFileChange) error {
+	if change.result == instructionFileSkipped {
+		return nil
+	}
+	if err := document.Write(change.absolutePath, change.after); err != nil {
+		return fmt.Errorf("failed to write %s: %w", change.relativePath, err)
+	}
+	return nil
+}

--- a/pkg/cli/init_refresh_diff.go
+++ b/pkg/cli/init_refresh_diff.go
@@ -1,0 +1,250 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+)
+
+const initRefreshDiffContext = 3
+
+type initRefreshDiffOp struct {
+	kind string
+	line string
+}
+
+func printInitRefreshDryRun(changes []initRefreshFileChange, stats initRefreshStats, opts initRefreshOptions) {
+	if opts.diff {
+		diff := renderInitRefreshDiff(changes)
+		if strings.TrimSpace(diff) == "" {
+			fmt.Println("No Kit-managed file changes planned.")
+		} else {
+			fmt.Print(diff)
+		}
+	}
+
+	if opts.outputOnly {
+		return
+	}
+
+	if !opts.diff {
+		fmt.Println("🔎 Kit project refresh dry run:")
+		for _, change := range changes {
+			if change.result == instructionFileSkipped {
+				continue
+			}
+			fmt.Printf("   %s %s\n", dryRunActionLabel(change.result), change.relativePath)
+		}
+		if stats.created+stats.updated+stats.merged == 0 {
+			fmt.Println("   No Kit-managed file changes planned.")
+		}
+	}
+
+	fmt.Printf(
+		"\nDry run complete. Planned Created: %d, Updated: %d, Merged: %d, Skipped: %d\n",
+		stats.created,
+		stats.updated,
+		stats.merged,
+		stats.skipped,
+	)
+}
+
+func dryRunActionLabel(result instructionFileWriteResult) string {
+	switch result {
+	case instructionFileCreated:
+		return "create"
+	case instructionFileUpdated:
+		return "update"
+	case instructionFileMerged:
+		return "merge"
+	default:
+		return "skip"
+	}
+}
+
+func renderInitRefreshDiff(changes []initRefreshFileChange) string {
+	var builder strings.Builder
+	for _, change := range changes {
+		if change.result == instructionFileSkipped {
+			continue
+		}
+		if change.result != instructionFileCreated && change.before == change.after {
+			continue
+		}
+		builder.WriteString(renderInitRefreshFileDiff(change))
+	}
+	return builder.String()
+}
+
+func renderInitRefreshFileDiff(change initRefreshFileChange) string {
+	oldPath := "a/" + change.relativePath
+	newPath := "b/" + change.relativePath
+
+	var builder strings.Builder
+	fmt.Fprintf(&builder, "diff --git %s %s\n", oldPath, newPath)
+	if change.result == instructionFileCreated {
+		builder.WriteString("new file mode 100644\n")
+		builder.WriteString("--- /dev/null\n")
+	} else {
+		fmt.Fprintf(&builder, "--- %s\n", oldPath)
+	}
+	fmt.Fprintf(&builder, "+++ %s\n", newPath)
+
+	for _, hunk := range unifiedDiffHunks(splitDiffLines(change.before), splitDiffLines(change.after), initRefreshDiffContext) {
+		builder.WriteString(hunk)
+	}
+	return builder.String()
+}
+
+func splitDiffLines(content string) []string {
+	if content == "" {
+		return nil
+	}
+	lines := strings.SplitAfter(content, "\n")
+	if lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+	for i, line := range lines {
+		lines[i] = strings.TrimSuffix(line, "\n")
+	}
+	return lines
+}
+
+func unifiedDiffHunks(oldLines, newLines []string, context int) []string {
+	ops := buildDiffOps(oldLines, newLines)
+	var changed []int
+	for i, op := range ops {
+		if op.kind != "equal" {
+			changed = append(changed, i)
+		}
+	}
+	if len(changed) == 0 {
+		return nil
+	}
+
+	var hunks []string
+	for i := 0; i < len(changed); {
+		changeStart := changed[i]
+		changeEnd := changeStart
+		i++
+		for i < len(changed) && changed[i]-changeEnd <= context*2 {
+			changeEnd = changed[i]
+			i++
+		}
+
+		start := changeStart - context
+		if start < 0 {
+			start = 0
+		}
+		end := changeEnd + context
+		if end >= len(ops) {
+			end = len(ops) - 1
+		}
+		hunks = append(hunks, renderDiffHunk(ops, start, end))
+	}
+	return hunks
+}
+
+func buildDiffOps(oldLines, newLines []string) []initRefreshDiffOp {
+	oldLen := len(oldLines)
+	newLen := len(newLines)
+	table := make([][]int, oldLen+1)
+	for i := range table {
+		table[i] = make([]int, newLen+1)
+	}
+	for i := oldLen - 1; i >= 0; i-- {
+		for j := newLen - 1; j >= 0; j-- {
+			if oldLines[i] == newLines[j] {
+				table[i][j] = table[i+1][j+1] + 1
+				continue
+			}
+			if table[i+1][j] >= table[i][j+1] {
+				table[i][j] = table[i+1][j]
+			} else {
+				table[i][j] = table[i][j+1]
+			}
+		}
+	}
+
+	var ops []initRefreshDiffOp
+	i, j := 0, 0
+	for i < oldLen && j < newLen {
+		if oldLines[i] == newLines[j] {
+			ops = append(ops, initRefreshDiffOp{kind: "equal", line: oldLines[i]})
+			i++
+			j++
+			continue
+		}
+		if table[i+1][j] >= table[i][j+1] {
+			ops = append(ops, initRefreshDiffOp{kind: "delete", line: oldLines[i]})
+			i++
+		} else {
+			ops = append(ops, initRefreshDiffOp{kind: "insert", line: newLines[j]})
+			j++
+		}
+	}
+	for i < oldLen {
+		ops = append(ops, initRefreshDiffOp{kind: "delete", line: oldLines[i]})
+		i++
+	}
+	for j < newLen {
+		ops = append(ops, initRefreshDiffOp{kind: "insert", line: newLines[j]})
+		j++
+	}
+	return ops
+}
+
+func renderDiffHunk(ops []initRefreshDiffOp, start int, end int) string {
+	oldBefore, newBefore := diffLineCounts(ops[:start])
+	oldCount, newCount := diffLineCounts(ops[start : end+1])
+	oldStart := oldBefore + 1
+	newStart := newBefore + 1
+	if oldCount == 0 {
+		oldStart = oldBefore
+	}
+	if newCount == 0 {
+		newStart = newBefore
+	}
+
+	var builder strings.Builder
+	fmt.Fprintf(
+		&builder,
+		"@@ -%s +%s @@\n",
+		diffRange(oldStart, oldCount),
+		diffRange(newStart, newCount),
+	)
+	for _, op := range ops[start : end+1] {
+		switch op.kind {
+		case "equal":
+			builder.WriteString(" ")
+		case "delete":
+			builder.WriteString("-")
+		case "insert":
+			builder.WriteString("+")
+		}
+		builder.WriteString(op.line)
+		builder.WriteString("\n")
+	}
+	return builder.String()
+}
+
+func diffLineCounts(ops []initRefreshDiffOp) (oldCount int, newCount int) {
+	for _, op := range ops {
+		switch op.kind {
+		case "equal":
+			oldCount++
+			newCount++
+		case "delete":
+			oldCount++
+		case "insert":
+			newCount++
+		}
+	}
+	return oldCount, newCount
+}
+
+func diffRange(start int, count int) string {
+	if count == 1 {
+		return fmt.Sprintf("%d", start)
+	}
+	return fmt.Sprintf("%d,%d", start, count)
+}

--- a/pkg/cli/init_refresh_files.go
+++ b/pkg/cli/init_refresh_files.go
@@ -11,7 +11,7 @@ import (
 	"github.com/jamesonstone/kit/internal/templates"
 )
 
-func refreshInitScaffoldFiles(projectRoot string, opts initRefreshOptions, targets map[string]bool, stats *initRefreshStats) error {
+func planRefreshInitScaffoldFiles(projectRoot string, opts initRefreshOptions, targets map[string]bool) ([]initRefreshFileChange, error) {
 	files := []struct {
 		relativePath string
 		content      string
@@ -24,117 +24,126 @@ func refreshInitScaffoldFiles(projectRoot string, opts initRefreshOptions, targe
 		{relativePath: pullRequestTemplatePath, content: templates.PullRequestTemplate},
 	}
 
+	var changes []initRefreshFileChange
 	for _, file := range files {
 		if !initRefreshTargetMatches(targets, file.relativePath) {
 			continue
 		}
-		err := refreshInitScaffoldFile(projectRoot, opts, targets, file.relativePath, file.content, file.merge, stats)
+		change, err := planRefreshInitScaffoldFile(projectRoot, opts, targets, file.relativePath, file.content, file.merge)
 		if err != nil {
-			return err
+			return nil, err
 		}
+		changes = append(changes, change)
 	}
-	return nil
+	return changes, nil
 }
 
-func refreshInitScaffoldFile(
+func planRefreshInitScaffoldFile(
 	projectRoot string,
 	opts initRefreshOptions,
 	targets map[string]bool,
 	relativePath string,
 	content string,
 	merge bool,
-	stats *initRefreshStats,
-) error {
+) (initRefreshFileChange, error) {
 	path := filepath.Join(projectRoot, filepath.FromSlash(relativePath))
 	exists := document.Exists(path)
 	explicit := len(targets) > 0
 
-	if exists && opts.force && explicit {
-		if err := document.Write(path, content); err != nil {
-			return fmt.Errorf("failed to overwrite %s: %w", relativePath, err)
-		}
-		stats.updated++
-		return nil
-	}
-	if exists && merge {
+	var before string
+	if exists {
 		data, err := os.ReadFile(path)
 		if err != nil {
-			return fmt.Errorf("failed to read %s: %w", relativePath, err)
+			return initRefreshFileChange{}, fmt.Errorf("failed to read %s: %w", relativePath, err)
 		}
-		missing := missingGitignorePatterns(string(data))
+		before = string(data)
+	}
+
+	if exists && opts.force && explicit {
+		return *newInitRefreshFileChange(projectRoot, relativePath, before, content, instructionFileUpdated), nil
+	}
+	if exists && merge {
+		missing := missingGitignorePatterns(before)
 		if len(missing) == 0 {
-			stats.skipped++
-			return nil
+			return *newInitRefreshFileChange(projectRoot, relativePath, before, before, instructionFileSkipped), nil
 		}
-		if err := document.Write(path, appendGitignorePatterns(string(data), missing)); err != nil {
-			return fmt.Errorf("failed to update %s: %w", relativePath, err)
-		}
-		stats.merged++
-		return nil
+		return *newInitRefreshFileChange(
+			projectRoot,
+			relativePath,
+			before,
+			appendGitignorePatterns(before, missing),
+			instructionFileMerged,
+		), nil
 	}
 	if exists {
-		stats.skipped++
-		return nil
+		return *newInitRefreshFileChange(projectRoot, relativePath, before, before, instructionFileSkipped), nil
 	}
-	if err := document.Write(path, content); err != nil {
-		return fmt.Errorf("failed to create %s: %w", relativePath, err)
-	}
-	stats.created++
-	return nil
+	return *newInitRefreshFileChange(projectRoot, relativePath, before, content, instructionFileCreated), nil
 }
 
-func refreshInitConstitution(projectRoot string, cfg *config.Config, targets map[string]bool, stats *initRefreshStats) error {
+func planRefreshInitConstitution(projectRoot string, cfg *config.Config, targets map[string]bool) (*initRefreshFileChange, error) {
 	relativePath := filepath.ToSlash(cfg.ConstitutionPath)
 	if !initRefreshTargetMatches(targets, relativePath) {
-		return nil
+		return nil, nil
 	}
 
 	path := filepath.Join(projectRoot, filepath.FromSlash(relativePath))
-	created := false
-	if !document.Exists(path) {
-		if err := document.Write(path, templates.Constitution); err != nil {
-			return fmt.Errorf("failed to create %s: %w", relativePath, err)
+	exists := document.Exists(path)
+	before := ""
+	after := templates.Constitution
+	result := instructionFileCreated
+	if exists {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read %s: %w", relativePath, err)
 		}
-		stats.created++
-		created = true
+		before = string(data)
+		after = before
+		result = instructionFileSkipped
+	}
+	after = mergeDocumentContent(relativePath, after, templates.Constitution, document.TypeConstitution)
+	updated, changed := upsertConstitutionBaseline(after)
+	if changed {
+		after = updated
 	}
 
-	before, err := os.ReadFile(path)
-	if err != nil {
-		return fmt.Errorf("failed to read %s: %w", relativePath, err)
+	if exists && before != after {
+		result = instructionFileMerged
 	}
-	if err := document.MergeDocument(path, templates.Constitution, document.TypeConstitution); err != nil {
-		return fmt.Errorf("failed to merge %s: %w", relativePath, err)
+	if exists && before == after {
+		result = instructionFileSkipped
 	}
-	merged, err := os.ReadFile(path)
-	if err != nil {
-		return fmt.Errorf("failed to read %s: %w", relativePath, err)
-	}
-	updated, changed := upsertConstitutionBaseline(string(merged))
-	if changed {
-		if err := document.Write(path, updated); err != nil {
-			return fmt.Errorf("failed to update %s: %w", relativePath, err)
-		}
-		stats.merged++
-		return nil
-	}
-	if string(before) != string(merged) {
-		stats.merged++
-		return nil
-	}
-	if !created {
-		stats.skipped++
-	}
-	return nil
+	return newInitRefreshFileChange(projectRoot, relativePath, before, after, result), nil
 }
 
-func refreshInitInstructionArtifacts(
+func mergeDocumentContent(path string, content string, templateContent string, docType document.DocumentType) string {
+	existing := document.Parse(content, path, docType)
+	template := document.Parse(templateContent, "", docType)
+
+	var missingSections []document.Section
+	for _, section := range template.Sections {
+		if !existing.HasSection(section.Name) {
+			missingSections = append(missingSections, section)
+		}
+	}
+	if len(missingSections) == 0 {
+		return content
+	}
+
+	merged := content
+	for _, section := range missingSections {
+		merged += fmt.Sprintf("\n\n## %s\n\n%s", section.Name, section.Content)
+	}
+	return merged
+}
+
+func planRefreshInitInstructionArtifacts(
 	projectRoot string,
 	opts initRefreshOptions,
 	cfg *config.Config,
 	targets map[string]bool,
-	stats *initRefreshStats,
-) error {
+) ([]initRefreshFileChange, error) {
+	var changes []initRefreshFileChange
 	for _, relativePath := range instructionArtifactPaths(
 		cfg,
 		instructionFileSelection{},
@@ -151,24 +160,40 @@ func refreshInitInstructionArtifacts(
 		}
 		plan, err := planInstructionArtifactWrite(projectRoot, relativePath, mode, config.InstructionScaffoldVersionTOC)
 		if err != nil {
-			return err
+			return nil, err
 		}
-		result, err := applyInstructionFileWritePlan(plan)
+		change, err := initRefreshChangeFromInstructionPlan(projectRoot, plan)
 		if err != nil {
-			return err
+			return nil, err
 		}
-		stats.recordInstructionResult(result)
+		changes = append(changes, change)
 	}
-	return nil
+	return changes, nil
 }
 
-func refreshInitRulesets(
+func initRefreshChangeFromInstructionPlan(projectRoot string, plan instructionFileWritePlan) (initRefreshFileChange, error) {
+	before := ""
+	after := plan.content
+	if document.Exists(plan.absolutePath) {
+		data, err := os.ReadFile(plan.absolutePath)
+		if err != nil {
+			return initRefreshFileChange{}, fmt.Errorf("failed to read %s: %w", plan.relativePath, err)
+		}
+		before = string(data)
+		if plan.result == instructionFileSkipped {
+			after = before
+		}
+	}
+	return *newInitRefreshFileChange(projectRoot, plan.relativePath, before, after, plan.result), nil
+}
+
+func planRefreshInitRulesets(
 	projectRoot string,
 	opts initRefreshOptions,
 	targets map[string]bool,
 	registry []registryRuleset,
-	stats *initRefreshStats,
-) error {
+) ([]initRefreshFileChange, error) {
+	var changes []initRefreshFileChange
 	for _, item := range registry {
 		relativePath := rulesetTarget(item.Slug)
 		if !initRefreshTargetMatches(targets, relativePath) {
@@ -176,20 +201,31 @@ func refreshInitRulesets(
 		}
 		path := filepath.Join(projectRoot, filepath.FromSlash(relativePath))
 		exists := document.Exists(path)
+		before := ""
+		if exists {
+			data, err := os.ReadFile(path)
+			if err != nil {
+				return nil, fmt.Errorf("failed to read %s: %w", relativePath, err)
+			}
+			before = string(data)
+		}
 		if exists && !opts.force {
-			stats.skipped++
+			changes = append(changes, *newInitRefreshFileChange(
+				projectRoot,
+				relativePath,
+				before,
+				before,
+				instructionFileSkipped,
+			))
 			continue
 		}
-		if err := document.Write(path, item.Content); err != nil {
-			return fmt.Errorf("failed to write %s: %w", relativePath, err)
-		}
+		result := instructionFileCreated
 		if exists {
-			stats.updated++
-		} else {
-			stats.created++
+			result = instructionFileUpdated
 		}
+		changes = append(changes, *newInitRefreshFileChange(projectRoot, relativePath, before, item.Content, result))
 	}
-	return nil
+	return changes, nil
 }
 
 func exactLegacyInstructionArtifact(projectRoot, relativePath string) bool {

--- a/pkg/cli/init_refresh_files.go
+++ b/pkg/cli/init_refresh_files.go
@@ -1,0 +1,254 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/jamesonstone/kit/internal/config"
+	"github.com/jamesonstone/kit/internal/document"
+	"github.com/jamesonstone/kit/internal/templates"
+)
+
+func refreshInitScaffoldFiles(projectRoot string, opts initRefreshOptions, targets map[string]bool, stats *initRefreshStats) error {
+	files := []struct {
+		relativePath string
+		content      string
+		merge        bool
+	}{
+		{relativePath: gitignorePath, content: templates.Gitignore, merge: true},
+		{relativePath: envPath, content: ""},
+		{relativePath: envrcPath, content: templates.Envrc},
+		{relativePath: codeRabbitConfigPath, content: templates.CodeRabbitConfig},
+		{relativePath: pullRequestTemplatePath, content: templates.PullRequestTemplate},
+	}
+
+	for _, file := range files {
+		if !initRefreshTargetMatches(targets, file.relativePath) {
+			continue
+		}
+		err := refreshInitScaffoldFile(projectRoot, opts, targets, file.relativePath, file.content, file.merge, stats)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func refreshInitScaffoldFile(
+	projectRoot string,
+	opts initRefreshOptions,
+	targets map[string]bool,
+	relativePath string,
+	content string,
+	merge bool,
+	stats *initRefreshStats,
+) error {
+	path := filepath.Join(projectRoot, filepath.FromSlash(relativePath))
+	exists := document.Exists(path)
+	explicit := len(targets) > 0
+
+	if exists && opts.force && explicit {
+		if err := document.Write(path, content); err != nil {
+			return fmt.Errorf("failed to overwrite %s: %w", relativePath, err)
+		}
+		stats.updated++
+		return nil
+	}
+	if exists && merge {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return fmt.Errorf("failed to read %s: %w", relativePath, err)
+		}
+		missing := missingGitignorePatterns(string(data))
+		if len(missing) == 0 {
+			stats.skipped++
+			return nil
+		}
+		if err := document.Write(path, appendGitignorePatterns(string(data), missing)); err != nil {
+			return fmt.Errorf("failed to update %s: %w", relativePath, err)
+		}
+		stats.merged++
+		return nil
+	}
+	if exists {
+		stats.skipped++
+		return nil
+	}
+	if err := document.Write(path, content); err != nil {
+		return fmt.Errorf("failed to create %s: %w", relativePath, err)
+	}
+	stats.created++
+	return nil
+}
+
+func refreshInitConstitution(projectRoot string, cfg *config.Config, targets map[string]bool, stats *initRefreshStats) error {
+	relativePath := filepath.ToSlash(cfg.ConstitutionPath)
+	if !initRefreshTargetMatches(targets, relativePath) {
+		return nil
+	}
+
+	path := filepath.Join(projectRoot, filepath.FromSlash(relativePath))
+	created := false
+	if !document.Exists(path) {
+		if err := document.Write(path, templates.Constitution); err != nil {
+			return fmt.Errorf("failed to create %s: %w", relativePath, err)
+		}
+		stats.created++
+		created = true
+	}
+
+	before, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("failed to read %s: %w", relativePath, err)
+	}
+	if err := document.MergeDocument(path, templates.Constitution, document.TypeConstitution); err != nil {
+		return fmt.Errorf("failed to merge %s: %w", relativePath, err)
+	}
+	merged, err := os.ReadFile(path)
+	if err != nil {
+		return fmt.Errorf("failed to read %s: %w", relativePath, err)
+	}
+	updated, changed := upsertConstitutionBaseline(string(merged))
+	if changed {
+		if err := document.Write(path, updated); err != nil {
+			return fmt.Errorf("failed to update %s: %w", relativePath, err)
+		}
+		stats.merged++
+		return nil
+	}
+	if string(before) != string(merged) {
+		stats.merged++
+		return nil
+	}
+	if !created {
+		stats.skipped++
+	}
+	return nil
+}
+
+func refreshInitInstructionArtifacts(
+	projectRoot string,
+	opts initRefreshOptions,
+	cfg *config.Config,
+	targets map[string]bool,
+	stats *initRefreshStats,
+) error {
+	for _, relativePath := range instructionArtifactPaths(
+		cfg,
+		instructionFileSelection{},
+		config.InstructionScaffoldVersionTOC,
+		true,
+	) {
+		relativePath = filepath.ToSlash(relativePath)
+		if !initRefreshTargetMatches(targets, relativePath) {
+			continue
+		}
+		mode := instructionFileWriteModeAppendOnly
+		if opts.force || exactLegacyInstructionArtifact(projectRoot, relativePath) {
+			mode = instructionFileWriteModeOverwrite
+		}
+		plan, err := planInstructionArtifactWrite(projectRoot, relativePath, mode, config.InstructionScaffoldVersionTOC)
+		if err != nil {
+			return err
+		}
+		result, err := applyInstructionFileWritePlan(plan)
+		if err != nil {
+			return err
+		}
+		stats.recordInstructionResult(result)
+	}
+	return nil
+}
+
+func refreshInitRulesets(
+	projectRoot string,
+	opts initRefreshOptions,
+	targets map[string]bool,
+	registry []registryRuleset,
+	stats *initRefreshStats,
+) error {
+	for _, item := range registry {
+		relativePath := rulesetTarget(item.Slug)
+		if !initRefreshTargetMatches(targets, relativePath) {
+			continue
+		}
+		path := filepath.Join(projectRoot, filepath.FromSlash(relativePath))
+		exists := document.Exists(path)
+		if exists && !opts.force {
+			stats.skipped++
+			continue
+		}
+		if err := document.Write(path, item.Content); err != nil {
+			return fmt.Errorf("failed to write %s: %w", relativePath, err)
+		}
+		if exists {
+			stats.updated++
+		} else {
+			stats.created++
+		}
+	}
+	return nil
+}
+
+func exactLegacyInstructionArtifact(projectRoot, relativePath string) bool {
+	path := filepath.Join(projectRoot, filepath.FromSlash(relativePath))
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(content)) == strings.TrimSpace(templates.InstructionFileForVersion(relativePath, config.InstructionScaffoldVersionVerbose))
+}
+
+func upsertConstitutionBaseline(content string) (string, bool) {
+	lines := strings.Split(strings.TrimRight(content, "\n"), "\n")
+	start := -1
+	for i, line := range lines {
+		if strings.TrimSpace(line) == "### "+constitutionBaselineHeading {
+			start = i
+			break
+		}
+	}
+
+	baselineLines := strings.Split(constitutionBaselineSection, "\n")
+	if start >= 0 {
+		end := len(lines)
+		for i := start + 1; i < len(lines); i++ {
+			trimmed := strings.TrimSpace(lines[i])
+			if strings.HasPrefix(trimmed, "### ") || strings.HasPrefix(trimmed, "## ") {
+				end = i
+				break
+			}
+		}
+		updatedLines := append([]string{}, lines[:start]...)
+		updatedLines = append(updatedLines, baselineLines...)
+		updatedLines = append(updatedLines, lines[end:]...)
+		updated := strings.Join(updatedLines, "\n") + "\n"
+		return updated, updated != content
+	}
+
+	constraints := -1
+	for i, line := range lines {
+		if strings.TrimSpace(line) == "## CONSTRAINTS" {
+			constraints = i
+			break
+		}
+	}
+	if constraints == -1 {
+		updated := strings.TrimRight(content, "\n") + "\n\n## CONSTRAINTS\n\n" + constitutionBaselineSection + "\n"
+		return updated, true
+	}
+
+	insertAt := constraints + 1
+	for insertAt < len(lines) && strings.TrimSpace(lines[insertAt]) == "" {
+		insertAt++
+	}
+
+	updatedLines := append([]string{}, lines[:insertAt]...)
+	updatedLines = append(updatedLines, "")
+	updatedLines = append(updatedLines, baselineLines...)
+	updatedLines = append(updatedLines, "")
+	updatedLines = append(updatedLines, lines[insertAt:]...)
+	return strings.Join(updatedLines, "\n") + "\n", true
+}

--- a/pkg/cli/init_test.go
+++ b/pkg/cli/init_test.go
@@ -586,6 +586,110 @@ func TestRunInitRefresh_RejectsUnsupportedFileTarget(t *testing.T) {
 	})
 }
 
+func TestRunInitRefresh_DryRunDiffPrintsPlannedChangesWithoutWriting(t *testing.T) {
+	tempDir := t.TempDir()
+	setupInitHome(t)
+	setWorkingDirectory(t, tempDir)
+
+	existing := "source_env .custom\n"
+	writeFile(t, filepath.Join(tempDir, envrcPath), existing)
+
+	var output string
+	withInitFlags(t, func() {
+		initRefresh = true
+		initDryRun = true
+		initDiff = true
+		initForce = true
+		initRefreshFiles = []string{envrcPath}
+
+		output = captureStdout(t, func() {
+			if err := runInit(initCmd, nil); err != nil {
+				t.Fatalf("runInit() error = %v", err)
+			}
+		})
+	})
+
+	for _, check := range []string{
+		"diff --git a/.envrc b/.envrc",
+		"--- a/.envrc",
+		"+++ b/.envrc",
+		"-source_env .custom",
+		"+dotenv_if_exists",
+		"Dry run complete. Planned Created: 0, Updated: 1, Merged: 0, Skipped: 0",
+	} {
+		if !strings.Contains(output, check) {
+			t.Fatalf("expected dry-run diff output to contain %q, got:\n%s", check, output)
+		}
+	}
+
+	content, err := os.ReadFile(filepath.Join(tempDir, envrcPath))
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", envrcPath, err)
+	}
+	if string(content) != existing {
+		t.Fatalf("dry run wrote %s; content = %q, want %q", envrcPath, content, existing)
+	}
+}
+
+func TestRunInitRefresh_DryRunDoesNotWritePlannedRefresh(t *testing.T) {
+	tempDir := t.TempDir()
+	setupInitHome(t)
+	setWorkingDirectory(t, tempDir)
+	stubRulesetRegistry(t)
+
+	cfg := config.Default()
+	cfg.InstructionScaffoldVersion = config.InstructionScaffoldVersionVerbose
+	if err := config.Save(tempDir, cfg); err != nil {
+		t.Fatalf("failed to save config: %v", err)
+	}
+	writeFile(t, filepath.Join(tempDir, agentsMDPath), templates.LegacyAgentsMD)
+
+	withInitFlags(t, func() {
+		initRefresh = true
+		initDryRun = true
+		initOutputOnly = true
+
+		_ = captureStdout(t, func() {
+			if err := runInit(initCmd, nil); err != nil {
+				t.Fatalf("runInit() error = %v", err)
+			}
+		})
+	})
+
+	unchanged, err := config.Load(tempDir)
+	if err != nil {
+		t.Fatalf("config.Load() error = %v", err)
+	}
+	if unchanged.InstructionScaffoldVersion != config.InstructionScaffoldVersionVerbose {
+		t.Fatalf("dry run updated config version = %d", unchanged.InstructionScaffoldVersion)
+	}
+
+	agentsContent, err := os.ReadFile(filepath.Join(tempDir, agentsMDPath))
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", agentsMDPath, err)
+	}
+	if string(agentsContent) != templates.LegacyAgentsMD {
+		t.Fatalf("dry run updated %s", agentsMDPath)
+	}
+	assertFileDoesNotExist(t, filepath.Join(tempDir, "docs", "agents", "README.md"))
+}
+
+func TestRunInit_DiffRequiresDryRun(t *testing.T) {
+	tempDir := t.TempDir()
+	setupInitHome(t)
+	setWorkingDirectory(t, tempDir)
+
+	withInitFlags(t, func() {
+		initRefresh = true
+		initDiff = true
+
+		err := runInit(initCmd, nil)
+		if err == nil || !strings.Contains(err.Error(), "--diff requires --dry-run") {
+			t.Fatalf("expected --diff without --dry-run error, got %v", err)
+		}
+	})
+}
+
 func initTestSupportFileContent(relativePath string) string {
 	for _, file := range templates.InstructionSupportFiles(config.InstructionScaffoldVersionTOC) {
 		if file.RelativePath == relativePath {
@@ -602,6 +706,8 @@ func withInitFlags(t *testing.T, run func()) {
 	originalOutputOnly := initOutputOnly
 	originalRefresh := initRefresh
 	originalForce := initForce
+	originalDryRun := initDryRun
+	originalDiff := initDiff
 	originalRefreshFiles := initRefreshFiles
 
 	t.Cleanup(func() {
@@ -609,6 +715,8 @@ func withInitFlags(t *testing.T, run func()) {
 		initOutputOnly = originalOutputOnly
 		initRefresh = originalRefresh
 		initForce = originalForce
+		initDryRun = originalDryRun
+		initDiff = originalDiff
 		initRefreshFiles = originalRefreshFiles
 	})
 
@@ -616,6 +724,8 @@ func withInitFlags(t *testing.T, run func()) {
 	initOutputOnly = false
 	initRefresh = false
 	initForce = false
+	initDryRun = false
+	initDiff = false
 	initRefreshFiles = nil
 
 	run()

--- a/pkg/cli/init_test.go
+++ b/pkg/cli/init_test.go
@@ -415,19 +415,208 @@ func TestRunInit_PreservesExistingPullRequestTemplate(t *testing.T) {
 	})
 }
 
+func TestRunInitRefresh_MigratesGeneratedVerboseInstructionsAndCreatesManagedFiles(t *testing.T) {
+	tempDir := t.TempDir()
+	setupInitHome(t)
+	setWorkingDirectory(t, tempDir)
+	stubRulesetRegistry(t, registryRulesetForTest("safety-guardrails", []string{"git", "github"}))
+
+	cfg := config.Default()
+	cfg.InstructionScaffoldVersion = config.InstructionScaffoldVersionVerbose
+	if err := config.Save(tempDir, cfg); err != nil {
+		t.Fatalf("failed to save config: %v", err)
+	}
+	writeFile(t, filepath.Join(tempDir, agentsMDPath), templates.LegacyAgentsMD)
+	writeFile(t, filepath.Join(tempDir, claudeMDPath), templates.LegacyClaudeMD)
+	writeFile(t, filepath.Join(tempDir, copilotInstructionsPath), templates.LegacyCopilotInstructionsMD)
+	writeFile(t, filepath.Join(tempDir, "docs", "CONSTITUTION.md"), "# CONSTITUTION\n\n## PRINCIPLES\n\ncustom\n\n## CONSTRAINTS\n\ncustom\n\n## NON-GOALS\n\nnone\n\n## DEFINITIONS\n\nnone\n")
+	writeFile(t, filepath.Join(tempDir, envrcPath), "source_env .custom\n")
+
+	withInitFlags(t, func() {
+		initRefresh = true
+		initOutputOnly = true
+
+		_ = captureStdout(t, func() {
+			if err := runInit(initCmd, nil); err != nil {
+				t.Fatalf("runInit() error = %v", err)
+			}
+		})
+	})
+
+	updated, err := config.Load(tempDir)
+	if err != nil {
+		t.Fatalf("config.Load() error = %v", err)
+	}
+	if updated.InstructionScaffoldVersion != config.InstructionScaffoldVersionTOC {
+		t.Fatalf("InstructionScaffoldVersion = %d, want %d", updated.InstructionScaffoldVersion, config.InstructionScaffoldVersionTOC)
+	}
+
+	agentsContent, err := os.ReadFile(filepath.Join(tempDir, agentsMDPath))
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", agentsMDPath, err)
+	}
+	if string(agentsContent) != templates.AgentsMD {
+		t.Fatalf("expected generated v1 %s to migrate to v2 template", agentsMDPath)
+	}
+	assertFileExists(t, filepath.Join(tempDir, "docs", "agents", "README.md"))
+	assertFileExists(t, filepath.Join(tempDir, "docs", "references", "README.md"))
+
+	envrcContent, err := os.ReadFile(filepath.Join(tempDir, envrcPath))
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", envrcPath, err)
+	}
+	if string(envrcContent) != "source_env .custom\n" {
+		t.Fatalf("%s was overwritten during default refresh: %q", envrcPath, envrcContent)
+	}
+
+	constitutionContent, err := os.ReadFile(filepath.Join(tempDir, "docs", "CONSTITUTION.md"))
+	if err != nil {
+		t.Fatalf("failed to read CONSTITUTION.md: %v", err)
+	}
+	for _, check := range []string{
+		"custom",
+		"### Kit-Managed Baseline Rules",
+		"Do not apply the code-file size guideline to documentation files",
+	} {
+		if !strings.Contains(string(constitutionContent), check) {
+			t.Fatalf("expected CONSTITUTION.md to contain %q, got:\n%s", check, constitutionContent)
+		}
+	}
+
+	rulesetPath := filepath.Join(tempDir, "docs", "references", "rules", "safety-guardrails.md")
+	rulesetContent, err := os.ReadFile(rulesetPath)
+	if err != nil {
+		t.Fatalf("expected registry ruleset to be imported: %v", err)
+	}
+	if !strings.Contains(string(rulesetContent), "slug: safety-guardrails") {
+		t.Fatalf("unexpected ruleset content:\n%s", rulesetContent)
+	}
+}
+
+func TestRunInitRefresh_FileForceOverwritesOnlySelectedExistingFile(t *testing.T) {
+	tempDir := t.TempDir()
+	setupInitHome(t)
+	setWorkingDirectory(t, tempDir)
+
+	writeFile(t, filepath.Join(tempDir, envrcPath), "source_env .custom\n")
+	writeFile(t, filepath.Join(tempDir, codeRabbitConfigPath), "custom coderabbit\n")
+
+	withInitFlags(t, func() {
+		initRefresh = true
+		initForce = true
+		initOutputOnly = true
+		initRefreshFiles = []string{envrcPath}
+
+		_ = captureStdout(t, func() {
+			if err := runInit(initCmd, nil); err != nil {
+				t.Fatalf("runInit() error = %v", err)
+			}
+		})
+	})
+
+	envrcContent, err := os.ReadFile(filepath.Join(tempDir, envrcPath))
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", envrcPath, err)
+	}
+	if string(envrcContent) != templates.Envrc {
+		t.Fatalf("%s content = %q, want %q", envrcPath, envrcContent, templates.Envrc)
+	}
+
+	codeRabbitContent, err := os.ReadFile(filepath.Join(tempDir, codeRabbitConfigPath))
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", codeRabbitConfigPath, err)
+	}
+	if string(codeRabbitContent) != "custom coderabbit\n" {
+		t.Fatalf("%s content = %q, want custom content", codeRabbitConfigPath, codeRabbitContent)
+	}
+	assertFileDoesNotExist(t, filepath.Join(tempDir, agentsMDPath))
+}
+
+func TestRunInitRefresh_ForceDoesNotOverwriteExistingScaffoldFilesWithoutFileTarget(t *testing.T) {
+	tempDir := t.TempDir()
+	setupInitHome(t)
+	setWorkingDirectory(t, tempDir)
+	stubRulesetRegistry(t)
+
+	writeFile(t, filepath.Join(tempDir, envrcPath), "source_env .custom\n")
+	writeFile(t, filepath.Join(tempDir, "docs", "agents", "GUARDRAILS.md"), "# Guardrails\n\nold\n")
+
+	withInitFlags(t, func() {
+		initRefresh = true
+		initForce = true
+		initOutputOnly = true
+
+		_ = captureStdout(t, func() {
+			if err := runInit(initCmd, nil); err != nil {
+				t.Fatalf("runInit() error = %v", err)
+			}
+		})
+	})
+
+	envrcContent, err := os.ReadFile(filepath.Join(tempDir, envrcPath))
+	if err != nil {
+		t.Fatalf("failed to read %s: %v", envrcPath, err)
+	}
+	if string(envrcContent) != "source_env .custom\n" {
+		t.Fatalf("%s content = %q, want custom content", envrcPath, envrcContent)
+	}
+
+	guardrailsContent, err := os.ReadFile(filepath.Join(tempDir, "docs", "agents", "GUARDRAILS.md"))
+	if err != nil {
+		t.Fatalf("failed to read GUARDRAILS.md: %v", err)
+	}
+	if string(guardrailsContent) != initTestSupportFileContent("docs/agents/GUARDRAILS.md") {
+		t.Fatalf("expected generated docs support file to be overwritten on force, got:\n%s", guardrailsContent)
+	}
+}
+
+func TestRunInitRefresh_RejectsUnsupportedFileTarget(t *testing.T) {
+	tempDir := t.TempDir()
+	setupInitHome(t)
+	setWorkingDirectory(t, tempDir)
+
+	withInitFlags(t, func() {
+		initRefresh = true
+		initRefreshFiles = []string{"README.md"}
+
+		err := runInit(initCmd, nil)
+		if err == nil || !strings.Contains(err.Error(), "not a Kit-managed refresh target") {
+			t.Fatalf("expected unsupported target error, got %v", err)
+		}
+	})
+}
+
+func initTestSupportFileContent(relativePath string) string {
+	for _, file := range templates.InstructionSupportFiles(config.InstructionScaffoldVersionTOC) {
+		if file.RelativePath == relativePath {
+			return file.Content
+		}
+	}
+	return ""
+}
+
 func withInitFlags(t *testing.T, run func()) {
 	t.Helper()
 
 	originalCopy := initCopy
 	originalOutputOnly := initOutputOnly
+	originalRefresh := initRefresh
+	originalForce := initForce
+	originalRefreshFiles := initRefreshFiles
 
 	t.Cleanup(func() {
 		initCopy = originalCopy
 		initOutputOnly = originalOutputOnly
+		initRefresh = originalRefresh
+		initForce = originalForce
+		initRefreshFiles = originalRefreshFiles
 	})
 
 	initCopy = false
 	initOutputOnly = false
+	initRefresh = false
+	initForce = false
+	initRefreshFiles = nil
 
 	run()
 }


### PR DESCRIPTION
## Description

- :sparkles: Adds `kit init --refresh` as a consolidated refresh workflow for existing Kit projects.
- :dizzy: Creates missing Kit-managed scaffold files, refreshes generated instruction docs, migrates exact generated v1 instruction files to v2, and imports missing known registry rulesets.
- :wrench: Adds `--file` plus `--force` for targeted overwrites such as `kit init --refresh --file=.envrc --force`.
- :memo: Adds Kit-managed Constitution baseline refresh behavior and scopes the 300-line code-file guidance away from docs, `.kit/**`, and `.kit.yaml`.

## How to Test

1. `go test ./...`
2. `go run ./cmd/kit check --project`
3. `git diff --check`
4. Secret scan for common token/private key patterns

## Ticket

Closes #5
