### PR TITLE
:sparkles: import PR review comments into dispatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,11 @@ Use `kit dispatch` when you need the full overlap-clustering and queue-planning
 workflow for a raw task set. Use the default prompt path when the agent should
 use subagents opportunistically, and use `kit dispatch` when you want a formal
 discovery report, overlap clustering, and explicit approval before launch.
+Use `kit dispatch --pr <url|number>` to prefill the dispatch editor from
+unresolved, non-outdated GitHub PR review threads. Add `--coderabbit` to keep
+only CodeRabbit-authored review comments. `--pr` accepts a full GitHub PR URL, a
+Markdown PR link, `owner/repo#123`, or a PR number resolved from the current
+project's `origin` remote.
 
 ### 📋 Output Behavior
 

--- a/docs/specs/0008-dispatch-command/SPEC.md
+++ b/docs/specs/0008-dispatch-command/SPEC.md
@@ -133,6 +133,16 @@ none
 - [SPEC-26] The generated prompt must instruct the coding agent to wait for explicit user approval after the dry-run report and before launching any subagents.
 - [SPEC-27] The command must call `printWorkflowInstructions(...)` after prompt output when not in `--output-only` mode.
 - [SPEC-28] Root help and README must document the new command.
+- [SPEC-29] The command must support `--pr <url|number>` for fetching unresolved, non-outdated GitHub PR review threads through `gh`.
+- [SPEC-30] `--pr` must accept a GitHub PR URL, Markdown PR link, `owner/repo#number`, or a PR number resolved from the current project directory's `origin` remote.
+- [SPEC-31] With `--pr`, the command must prefill the existing dispatch editor with actionable review tasks before generating the normal dispatch prompt.
+- [SPEC-32] With `--pr --coderabbit`, the command must include only CodeRabbit-authored review comments.
+- [SPEC-33] With `--pr`, top-level PR comments are excluded; only PR review threads are included.
+- [SPEC-34] With `--pr`, resolved and outdated review threads are excluded.
+- [SPEC-35] With `--pr`, CodeRabbit `Prompt for AI Agents` blocks are extracted when present; otherwise the cleaned review comment body is used.
+- [SPEC-36] With `--pr`, repeated CodeRabbit boilerplate instructions are included once as common review instruction context instead of repeated inside every task.
+- [SPEC-37] With `--pr`, duplicate review tasks are removed by normalized task text plus source path and line.
+- [SPEC-38] With `--pr`, no matching actionable review threads prints a clear message and does not open the editor.
 
 ## ACCEPTANCE
 
@@ -148,6 +158,10 @@ none
 - Default command output copies the generated prompt to the clipboard, prints an acknowledgement, and does not print the prompt body.
 - `--output-only` prints the raw prompt to stdout, and `--output-only --copy` does both.
 - Help and README expose `kit dispatch` as a prompt-only command.
+- Running `kit dispatch --pr=https://github.com/Patient-Driven-Care/cortex/pull/67 --coderabbit` fetches unresolved, non-outdated CodeRabbit review-thread comments and pre-populates the dispatch editor.
+- Running `kit dispatch --pr=67` resolves PR 67 from the current project directory's `origin` GitHub remote.
+- Running `kit dispatch --pr='[Patient-Driven-Care/cortex#67](https://github.com/Patient-Driven-Care/cortex/pull/67)'` parses the PR from the Markdown link URL.
+- Running `kit dispatch --pr=<target>` with no matching unresolved, non-outdated review threads prints a clear no-actionable-comments message and does not open the editor.
 
 ## EDGE-CASES
 
@@ -157,6 +171,10 @@ none
 - The input contains multiple blank lines between task groups.
 - `--file` is passed together with piped stdin.
 - `--vim` or `--editor` is passed together with `--file` or piped stdin.
+- `--pr` is passed as a full GitHub URL, Markdown link, `owner/repo#number`, or current-repo number.
+- `--pr --coderabbit` is used on a PR with mixed CodeRabbit and human review threads.
+- A CodeRabbit review comment omits the `Prompt for AI Agents` block.
+- A PR has only resolved or outdated review threads.
 - `--max-subagents` is `0` or negative.
 - The file passed to `--file` does not exist.
 - `--output-only --copy` is passed and must both print and copy.

--- a/pkg/cli/dispatch.go
+++ b/pkg/cli/dispatch.go
@@ -3,15 +3,18 @@ package cli
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 )
 
 var (
 	dispatchCopy         bool
+	dispatchCodeRabbit   bool
 	dispatchEditor       string
 	dispatchFile         string
 	dispatchOutputOnly   bool
+	dispatchPR           string
 	dispatchUseVim       bool
 	dispatchMaxSubagents int
 )
@@ -23,9 +26,10 @@ var dispatchCmd = &cobra.Command{
 across a task set, cluster related work, and queue subagents safely.
 
 Input precedence:
-  1. --file
-  2. piped stdin
-  3. interactive editor-backed capture
+  1. --pr
+  2. --file
+  3. piped stdin
+  4. interactive editor-backed capture
 Interactive capture opens $EDITOR by default, falling back to a vim-compatible editor when $EDITOR is unset.
 
 The command never launches subagents itself. It only outputs the prompt.`,
@@ -36,6 +40,8 @@ The command never launches subagents itself. It only outputs the prompt.`,
 func init() {
 	addFreeTextInputFlags(dispatchCmd, &dispatchUseVim, &dispatchEditor)
 	dispatchCmd.Flags().StringVar(&dispatchFile, "file", "", "read the raw task set from a file")
+	dispatchCmd.Flags().StringVar(&dispatchPR, "pr", "", "fetch unresolved PR review threads from a PR URL, Markdown link, owner/repo#number, or current-repo number")
+	dispatchCmd.Flags().BoolVar(&dispatchCodeRabbit, "coderabbit", false, "with --pr, include only CodeRabbit-authored review comments")
 	dispatchCmd.Flags().BoolVar(&dispatchCopy, "copy", false, "copy prompt to clipboard even with --output-only")
 	dispatchCmd.Flags().BoolVar(
 		&dispatchOutputOnly,
@@ -59,12 +65,14 @@ func runDispatch(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	rawInput, inputSource, err := loadDispatchInput(
-		dispatchFile,
-		newFreeTextInputConfig(dispatchUseVim, dispatchEditor, false, true),
-	)
+	inputCfg := newFreeTextInputConfig(dispatchUseVim, dispatchEditor, false, true)
+	rawInput, inputSource, promptOptions, foundInput, err := loadDispatchInputForCommand(inputCfg)
 	if err != nil {
 		return err
+	}
+	if !foundInput {
+		fmt.Println("No actionable PR review comments found.")
+		return nil
 	}
 
 	tasks, err := normalizeDispatchTasks(rawInput)
@@ -77,7 +85,7 @@ func runDispatch(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to get working directory: %w", err)
 	}
 
-	prompt := buildDispatchPrompt(tasks, dispatchMaxSubagents, workingDirectory, inputSource)
+	prompt := buildDispatchPrompt(tasks, dispatchMaxSubagents, workingDirectory, inputSource, promptOptions)
 	if err := outputPromptWithoutSubagentsWithClipboardDefault(prompt, outputOnly, dispatchCopy); err != nil {
 		return err
 	}
@@ -90,6 +98,22 @@ func runDispatch(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+func loadDispatchInputForCommand(
+	inputCfg freeTextInputConfig,
+) (string, dispatchInputSource, dispatchPromptOptions, bool, error) {
+	if strings.TrimSpace(dispatchPR) != "" {
+		prInput, found, err := loadDispatchPRInput(dispatchPR, dispatchCodeRabbit, inputCfg)
+		return prInput.RawTasks,
+			dispatchInputSourcePR,
+			dispatchPromptOptions{CommonReviewInstruction: prInput.CommonReviewInstruction},
+			found,
+			err
+	}
+
+	rawInput, inputSource, err := loadDispatchInput(dispatchFile, inputCfg)
+	return rawInput, inputSource, dispatchPromptOptions{}, true, err
 }
 
 func validateDispatchMaxSubagents(maxSubagents int) error {

--- a/pkg/cli/dispatch_input.go
+++ b/pkg/cli/dispatch_input.go
@@ -11,6 +11,7 @@ type dispatchInputSource string
 
 const (
 	dispatchInputSourceFile   dispatchInputSource = "file"
+	dispatchInputSourcePR     dispatchInputSource = "pr-review"
 	dispatchInputSourceStdin  dispatchInputSource = "stdin"
 	dispatchInputSourceEditor dispatchInputSource = "editor"
 )

--- a/pkg/cli/dispatch_pr.go
+++ b/pkg/cli/dispatch_pr.go
@@ -1,0 +1,305 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+const coderabbitSharedReviewInstruction = `Verify each finding against current code. Fix only still-valid issues, skip the
+rest with a brief reason, keep changes minimal, and validate.`
+
+var (
+	dispatchCurrentRepoResolver    = resolveCurrentGitHubRepo
+	dispatchPRURLPattern           = regexp.MustCompile(`github\.com/([^/\s)]+)/([^/\s)]+)/pull/(\d+)`)
+	dispatchPROwnerNumberPattern   = regexp.MustCompile(`^([^/\s#]+)/([^/\s#]+)#(\d+)$`)
+	dispatchGitHubRemotePattern    = regexp.MustCompile(`github\.com[:/]([^/\s]+)/([^/\s]+?)(?:\.git)?$`)
+	dispatchPromptDetailsPattern   = regexp.MustCompile(`(?is)<details>\s*<summary>[^<]*Prompt for AI Agents?[^<]*</summary>(.*?)</details>`)
+	dispatchCodeFencePattern       = regexp.MustCompile("(?s)```(?:[a-zA-Z0-9_-]+)?\\s*\\n(.*?)\\n```")
+	dispatchDetailsPattern         = regexp.MustCompile(`(?is)<details>.*?</details>`)
+	dispatchSuggestionBlockPattern = regexp.MustCompile(`(?is)<!--\s*suggestion_start\s*-->.*?<!--\s*suggestion_end\s*-->`)
+	dispatchHTMLCommentPattern     = regexp.MustCompile(`(?is)<!--.*?-->`)
+	dispatchBoilerplatePattern     = regexp.MustCompile(`(?is)^\s*Verify each finding against current code\.\s*Fix only still-valid issues, skip the\s*rest with a brief reason, keep changes minimal, and validate\.\s*`)
+	dispatchWhitespacePattern      = regexp.MustCompile(`\s+`)
+)
+
+type dispatchPRTarget struct {
+	Owner  string
+	Repo   string
+	Number int
+}
+
+type dispatchReviewTask struct {
+	Author string
+	Body   string
+	Line   int
+	Path   string
+	URL    string
+}
+
+type dispatchPRInput struct {
+	CommonReviewInstruction string
+	RawTasks                string
+}
+
+type dispatchGitHubReviewThread struct {
+	IsOutdated bool   `json:"isOutdated"`
+	IsResolved bool   `json:"isResolved"`
+	Line       int    `json:"line"`
+	StartLine  int    `json:"startLine"`
+	Path       string `json:"path"`
+	Comments   struct {
+		Nodes []dispatchGitHubReviewComment `json:"nodes"`
+	} `json:"comments"`
+}
+
+type dispatchGitHubReviewComment struct {
+	Author struct {
+		Login string `json:"login"`
+	} `json:"author"`
+	Body string `json:"body"`
+	URL  string `json:"url"`
+}
+
+type dispatchGitHubReviewThreadResponse struct {
+	Data struct {
+		Repository struct {
+			PullRequest struct {
+				ReviewThreads struct {
+					Nodes    []dispatchGitHubReviewThread `json:"nodes"`
+					PageInfo struct {
+						EndCursor   string `json:"endCursor"`
+						HasNextPage bool   `json:"hasNextPage"`
+					} `json:"pageInfo"`
+				} `json:"reviewThreads"`
+			} `json:"pullRequest"`
+		} `json:"repository"`
+	} `json:"data"`
+	Errors []struct {
+		Message string `json:"message"`
+	} `json:"errors"`
+}
+
+func loadDispatchPRInput(
+	prRef string,
+	coderabbitOnly bool,
+	inputCfg freeTextInputConfig,
+) (dispatchPRInput, bool, error) {
+	target, err := resolveDispatchPRTarget(prRef)
+	if err != nil {
+		return dispatchPRInput{}, false, err
+	}
+
+	threads, err := fetchDispatchPRReviewThreads(target)
+	if err != nil {
+		return dispatchPRInput{}, false, err
+	}
+
+	input := buildDispatchPRInput(threads, coderabbitOnly)
+	if strings.TrimSpace(input.RawTasks) == "" {
+		return dispatchPRInput{}, false, nil
+	}
+
+	initialContent := renderDispatchPRInputForEditor(input)
+	edited, err := readEditorTextWithInitialContent(
+		inputCfg,
+		"dispatch review tasks",
+		initialContent,
+		false,
+		false,
+	)
+	if err != nil {
+		return dispatchPRInput{}, false, err
+	}
+
+	rawTasks, commonInstruction := splitDispatchPRInputFromEditor(edited, input.CommonReviewInstruction)
+	if strings.TrimSpace(rawTasks) == "" {
+		return dispatchPRInput{}, false, fmt.Errorf("dispatch review tasks cannot be empty")
+	}
+
+	return dispatchPRInput{
+		CommonReviewInstruction: commonInstruction,
+		RawTasks:                rawTasks,
+	}, true, nil
+}
+
+func resolveDispatchPRTarget(raw string) (dispatchPRTarget, error) {
+	value := strings.TrimSpace(raw)
+	if value == "" {
+		return dispatchPRTarget{}, fmt.Errorf("--pr cannot be empty")
+	}
+
+	if match := dispatchPRURLPattern.FindStringSubmatch(value); match != nil {
+		number, err := strconv.Atoi(match[3])
+		if err != nil {
+			return dispatchPRTarget{}, fmt.Errorf("invalid PR number %q: %w", match[3], err)
+		}
+		return dispatchPRTarget{Owner: match[1], Repo: match[2], Number: number}, nil
+	}
+
+	if parsed, err := url.Parse(value); err == nil && parsed.Host == "github.com" {
+		parts := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+		if len(parts) >= 4 && parts[2] == "pull" {
+			number, err := strconv.Atoi(parts[3])
+			if err != nil {
+				return dispatchPRTarget{}, fmt.Errorf("invalid PR number %q: %w", parts[3], err)
+			}
+			return dispatchPRTarget{Owner: parts[0], Repo: parts[1], Number: number}, nil
+		}
+	}
+
+	if match := dispatchPROwnerNumberPattern.FindStringSubmatch(value); match != nil {
+		number, err := strconv.Atoi(match[3])
+		if err != nil {
+			return dispatchPRTarget{}, fmt.Errorf("invalid PR number %q: %w", match[3], err)
+		}
+		return dispatchPRTarget{Owner: match[1], Repo: match[2], Number: number}, nil
+	}
+
+	if number, err := strconv.Atoi(value); err == nil {
+		owner, repo, err := dispatchCurrentRepoResolver()
+		if err != nil {
+			return dispatchPRTarget{}, err
+		}
+		return dispatchPRTarget{Owner: owner, Repo: repo, Number: number}, nil
+	}
+
+	return dispatchPRTarget{}, fmt.Errorf("could not parse PR reference %q", raw)
+}
+
+func resolveCurrentGitHubRepo() (string, string, error) {
+	output, err := commandOutput("git", "remote", "get-url", "origin")
+	if err != nil {
+		return "", "", fmt.Errorf("failed to resolve current repo from git remote origin: %w", err)
+	}
+
+	owner, repo, err := parseGitHubRemoteURL(strings.TrimSpace(string(output)))
+	if err != nil {
+		return "", "", err
+	}
+
+	return owner, repo, nil
+}
+
+func parseGitHubRemoteURL(raw string) (string, string, error) {
+	if match := dispatchGitHubRemotePattern.FindStringSubmatch(strings.TrimSpace(raw)); match != nil {
+		return match[1], strings.TrimSuffix(match[2], ".git"), nil
+	}
+
+	return "", "", fmt.Errorf("remote origin is not a GitHub repository URL: %s", raw)
+}
+
+func fetchDispatchPRReviewThreads(target dispatchPRTarget) ([]dispatchGitHubReviewThread, error) {
+	var all []dispatchGitHubReviewThread
+	cursor := ""
+
+	for {
+		response, err := fetchDispatchPRReviewThreadPage(target, cursor)
+		if err != nil {
+			return nil, err
+		}
+
+		page := response.Data.Repository.PullRequest.ReviewThreads
+		all = append(all, page.Nodes...)
+		if !page.PageInfo.HasNextPage {
+			return all, nil
+		}
+		cursor = page.PageInfo.EndCursor
+		if cursor == "" {
+			return nil, fmt.Errorf("GitHub reported another review-thread page without a cursor")
+		}
+	}
+}
+
+func fetchDispatchPRReviewThreadPage(
+	target dispatchPRTarget,
+	cursor string,
+) (dispatchGitHubReviewThreadResponse, error) {
+	query := dispatchPRReviewThreadsQuery(cursor != "")
+	args := []string{
+		"api", "graphql",
+		"-f", "query=" + query,
+		"-f", "owner=" + target.Owner,
+		"-f", "name=" + target.Repo,
+		"-F", fmt.Sprintf("number=%d", target.Number),
+	}
+	if cursor != "" {
+		args = append(args, "-f", "cursor="+cursor)
+	}
+
+	output, err := commandOutput("gh", args...)
+	if err != nil {
+		return dispatchGitHubReviewThreadResponse{}, fmt.Errorf("failed to fetch PR review threads: %w", err)
+	}
+
+	var response dispatchGitHubReviewThreadResponse
+	if err := json.Unmarshal(output, &response); err != nil {
+		return dispatchGitHubReviewThreadResponse{}, fmt.Errorf("failed to parse GitHub review thread response: %w", err)
+	}
+	if len(response.Errors) > 0 {
+		messages := make([]string, 0, len(response.Errors))
+		for _, graphErr := range response.Errors {
+			messages = append(messages, graphErr.Message)
+		}
+		return dispatchGitHubReviewThreadResponse{}, fmt.Errorf("GitHub GraphQL error: %s", strings.Join(messages, "; "))
+	}
+
+	return response, nil
+}
+
+func dispatchPRReviewThreadsQuery(withCursor bool) string {
+	after := ""
+	if withCursor {
+		after = ", after: $cursor"
+	}
+	cursorVar := ""
+	if withCursor {
+		cursorVar = ", $cursor: String!"
+	}
+
+	return fmt.Sprintf(`query($owner:String!, $name:String!, $number:Int!%s) {
+  repository(owner:$owner, name:$name) {
+    pullRequest(number:$number) {
+      reviewThreads(first:100%s) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          isResolved
+          isOutdated
+          path
+          line
+          startLine
+          comments(first:20) {
+            nodes {
+              author { login }
+              body
+              url
+            }
+          }
+        }
+      }
+    }
+  }
+}`, cursorVar, after)
+}
+
+func commandOutput(name string, args ...string) ([]byte, error) {
+	cmd := execCommand(name, args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if ok := strings.TrimSpace(string(output)); ok != "" {
+			if errors.As(err, &exitErr) {
+				return nil, fmt.Errorf("%s: %s", err, ok)
+			}
+			return nil, fmt.Errorf("%w: %s", err, ok)
+		}
+		return nil, err
+	}
+
+	return output, nil
+}

--- a/pkg/cli/dispatch_pr_extract.go
+++ b/pkg/cli/dispatch_pr_extract.go
@@ -1,0 +1,241 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+)
+
+func buildDispatchPRInput(
+	threads []dispatchGitHubReviewThread,
+	coderabbitOnly bool,
+) dispatchPRInput {
+	tasks, sawSharedInstruction := extractDispatchReviewTasks(threads, coderabbitOnly)
+	if len(tasks) == 0 {
+		return dispatchPRInput{}
+	}
+
+	var commonInstruction string
+	if sawSharedInstruction {
+		commonInstruction = coderabbitSharedReviewInstruction
+	}
+
+	return dispatchPRInput{
+		CommonReviewInstruction: commonInstruction,
+		RawTasks:                renderDispatchReviewTasks(tasks),
+	}
+}
+
+func extractDispatchReviewTasks(
+	threads []dispatchGitHubReviewThread,
+	coderabbitOnly bool,
+) ([]dispatchReviewTask, bool) {
+	var (
+		tasks                []dispatchReviewTask
+		seen                 = map[string]bool{}
+		sawSharedInstruction bool
+	)
+
+	for _, thread := range threads {
+		if thread.IsResolved || thread.IsOutdated {
+			continue
+		}
+
+		comment, ok := selectDispatchReviewComment(thread, coderabbitOnly)
+		if !ok {
+			continue
+		}
+
+		body, foundPrompt := extractPromptForAIAgents(comment.Body)
+		if foundPrompt {
+			var stripped bool
+			body, stripped = stripCoderabbitSharedInstruction(body)
+			sawSharedInstruction = sawSharedInstruction || stripped
+		} else {
+			body = cleanDispatchReviewComment(comment.Body)
+		}
+
+		body = normalizeDispatchRawInput(body)
+		if body == "" {
+			continue
+		}
+
+		line := thread.Line
+		if line == 0 {
+			line = thread.StartLine
+		}
+
+		key := dispatchReviewTaskDedupeKey(thread.Path, line, body)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+
+		tasks = append(tasks, dispatchReviewTask{
+			Author: comment.Author.Login,
+			Body:   body,
+			Line:   line,
+			Path:   thread.Path,
+			URL:    comment.URL,
+		})
+	}
+
+	return tasks, sawSharedInstruction
+}
+
+func selectDispatchReviewComment(
+	thread dispatchGitHubReviewThread,
+	coderabbitOnly bool,
+) (dispatchGitHubReviewComment, bool) {
+	for _, comment := range thread.Comments.Nodes {
+		if coderabbitOnly && !isCodeRabbitAuthor(comment.Author.Login) {
+			continue
+		}
+		return comment, true
+	}
+
+	return dispatchGitHubReviewComment{}, false
+}
+
+func isCodeRabbitAuthor(login string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(login))
+	return normalized == "coderabbitai" ||
+		normalized == "coderabbitai[bot]" ||
+		strings.Contains(normalized, "coderabbit")
+}
+
+func extractPromptForAIAgents(body string) (string, bool) {
+	match := dispatchPromptDetailsPattern.FindStringSubmatch(body)
+	if match == nil {
+		return "", false
+	}
+
+	content := strings.TrimSpace(match[1])
+	if fence := dispatchCodeFencePattern.FindStringSubmatch(content); fence != nil {
+		return normalizeDispatchRawInput(fence[1]), true
+	}
+
+	return normalizeDispatchRawInput(stripHTMLTags(content)), true
+}
+
+func stripCoderabbitSharedInstruction(body string) (string, bool) {
+	stripped := dispatchBoilerplatePattern.ReplaceAllString(body, "")
+	return normalizeDispatchRawInput(stripped), stripped != body
+}
+
+func cleanDispatchReviewComment(body string) string {
+	cleaned := dispatchSuggestionBlockPattern.ReplaceAllString(body, "")
+	cleaned = dispatchDetailsPattern.ReplaceAllString(cleaned, "")
+	cleaned = dispatchHTMLCommentPattern.ReplaceAllString(cleaned, "")
+	cleaned = stripMarkdownSeverityLine(cleaned)
+	cleaned = stripHTMLTags(cleaned)
+	return normalizeDispatchRawInput(cleaned)
+}
+
+func stripMarkdownSeverityLine(body string) string {
+	lines := strings.Split(body, "\n")
+	start := 0
+	for start < len(lines) {
+		line := strings.TrimSpace(lines[start])
+		if line == "" {
+			start++
+			continue
+		}
+		if strings.HasPrefix(line, "_") && strings.Contains(line, "Potential issue") {
+			start++
+			continue
+		}
+		break
+	}
+
+	return strings.Join(lines[start:], "\n")
+}
+
+func stripHTMLTags(body string) string {
+	replacer := strings.NewReplacer(
+		"<br>", "\n",
+		"<br/>", "\n",
+		"<br />", "\n",
+		"</p>", "\n",
+		"<p>", "",
+		"</strong>", "",
+		"<strong>", "",
+		"</em>", "",
+		"<em>", "",
+	)
+	return replacer.Replace(body)
+}
+
+func dispatchReviewTaskDedupeKey(path string, line int, body string) string {
+	normalizedBody := strings.ToLower(dispatchWhitespacePattern.ReplaceAllString(body, " "))
+	return fmt.Sprintf("%s:%d:%s", path, line, strings.TrimSpace(normalizedBody))
+}
+
+func renderDispatchPRInputForEditor(input dispatchPRInput) string {
+	var parts []string
+	if strings.TrimSpace(input.CommonReviewInstruction) != "" {
+		parts = append(parts, strings.TrimSpace(input.CommonReviewInstruction))
+	}
+	if strings.TrimSpace(input.RawTasks) != "" {
+		parts = append(parts, strings.TrimSpace(input.RawTasks))
+	}
+
+	return strings.Join(parts, "\n\n") + "\n"
+}
+
+func renderDispatchReviewTasks(tasks []dispatchReviewTask) string {
+	var sb strings.Builder
+	for _, task := range tasks {
+		lineLabel := task.Path
+		if task.Line > 0 {
+			lineLabel = fmt.Sprintf("%s:%d", task.Path, task.Line)
+		}
+
+		sb.WriteString("- Source: ")
+		sb.WriteString(lineLabel)
+		sb.WriteString("\n")
+		if strings.TrimSpace(task.Author) != "" {
+			sb.WriteString("  Author: ")
+			sb.WriteString(task.Author)
+			sb.WriteString("\n")
+		}
+		if strings.TrimSpace(task.URL) != "" {
+			sb.WriteString("  URL: ")
+			sb.WriteString(task.URL)
+			sb.WriteString("\n")
+		}
+		sb.WriteString("  Review task:\n")
+		for _, line := range strings.Split(task.Body, "\n") {
+			sb.WriteString("  ")
+			sb.WriteString(line)
+			sb.WriteString("\n")
+		}
+	}
+
+	return strings.TrimSpace(sb.String())
+}
+
+func splitDispatchPRInputFromEditor(
+	raw string,
+	defaultInstruction string,
+) (string, string) {
+	normalized := normalizeDispatchRawInput(raw)
+	if normalized == "" || strings.TrimSpace(defaultInstruction) == "" {
+		return normalized, ""
+	}
+
+	if strings.HasPrefix(normalized, defaultInstruction) {
+		rest := strings.TrimSpace(strings.TrimPrefix(normalized, defaultInstruction))
+		return rest, defaultInstruction
+	}
+
+	lines := strings.Split(normalized, "\n")
+	for index, line := range lines {
+		if _, isList := topLevelDispatchListItem(line); isList {
+			prefix := strings.TrimSpace(strings.Join(lines[:index], "\n"))
+			rest := strings.TrimSpace(strings.Join(lines[index:], "\n"))
+			return rest, prefix
+		}
+	}
+
+	return normalized, ""
+}

--- a/pkg/cli/dispatch_prompt.go
+++ b/pkg/cli/dispatch_prompt.go
@@ -12,6 +12,7 @@ func buildDispatchPrompt(
 	maxSubagents int,
 	workingDirectory string,
 	inputSource dispatchInputSource,
+	options dispatchPromptOptions,
 ) string {
 	return renderPromptDocument(func(doc *promptdoc.Document) {
 		doc.Paragraph("Prepare a subagent dispatch plan for the following task set.")
@@ -21,6 +22,10 @@ func buildDispatchPrompt(
 			fmt.Sprintf("Input source: %s", inputSource),
 			fmt.Sprintf("Effective max subagents: %d", maxSubagents),
 		)
+		if strings.TrimSpace(options.CommonReviewInstruction) != "" {
+			doc.Heading(2, "Common Review Instruction")
+			doc.CodeBlock("text", options.CommonReviewInstruction)
+		}
 		doc.Heading(2, "Normalized Tasks")
 		doc.Raw(renderDispatchTasks(tasks))
 		doc.Heading(2, "Your Task")
@@ -59,6 +64,10 @@ func buildDispatchPrompt(
 			"keep the dry-run report reviewable and explicit before asking for approval",
 		)
 	})
+}
+
+type dispatchPromptOptions struct {
+	CommonReviewInstruction string
 }
 
 func renderDispatchTasks(tasks []dispatchTask) string {

--- a/pkg/cli/dispatch_test.go
+++ b/pkg/cli/dispatch_test.go
@@ -11,7 +11,7 @@ func TestBuildDispatchPrompt(t *testing.T) {
 		{ID: "D002", Index: 2, Body: "Refresh README"},
 	}
 
-	prompt := buildDispatchPrompt(tasks, 10, "/tmp/project", dispatchInputSourceEditor)
+	prompt := buildDispatchPrompt(tasks, 10, "/tmp/project", dispatchInputSourceEditor, dispatchPromptOptions{})
 	checks := []string{
 		"Prepare a subagent dispatch plan",
 		"Working directory: /tmp/project",
@@ -43,6 +43,32 @@ func TestBuildDispatchPrompt(t *testing.T) {
 	}
 	if strings.Contains(prompt, "/plan") || strings.Contains(prompt, "planning mode") {
 		t.Fatalf("expected prompt to avoid native plan-mode triggers, got %q", prompt)
+	}
+}
+
+func TestBuildDispatchPromptIncludesCommonReviewInstruction(t *testing.T) {
+	tasks := []dispatchTask{
+		{ID: "D001", Index: 1, Body: "Source: internal/app.go:12\nReview task:\nFix the stale assertion"},
+	}
+
+	prompt := buildDispatchPrompt(
+		tasks,
+		4,
+		"/tmp/project",
+		dispatchInputSourcePR,
+		dispatchPromptOptions{CommonReviewInstruction: coderabbitSharedReviewInstruction},
+	)
+
+	checks := []string{
+		"Input source: pr-review",
+		"Common Review Instruction",
+		coderabbitSharedReviewInstruction,
+		"Fix the stale assertion",
+	}
+	for _, check := range checks {
+		if !strings.Contains(prompt, check) {
+			t.Fatalf("expected prompt to contain %q", check)
+		}
 	}
 }
 
@@ -94,6 +120,137 @@ func TestNormalizeDispatchTasksRejectsEmptyInput(t *testing.T) {
 	}
 }
 
+func TestResolveDispatchPRTargetParsesURLMarkdownAndOwnerNumber(t *testing.T) {
+	cases := []struct {
+		name string
+		raw  string
+		want dispatchPRTarget
+	}{
+		{
+			name: "url",
+			raw:  "https://github.com/Patient-Driven-Care/cortex/pull/67",
+			want: dispatchPRTarget{Owner: "Patient-Driven-Care", Repo: "cortex", Number: 67},
+		},
+		{
+			name: "markdown link",
+			raw:  "[Patient-Driven-Care/cortex#67](https://github.com/Patient-Driven-Care/cortex/pull/67)",
+			want: dispatchPRTarget{Owner: "Patient-Driven-Care", Repo: "cortex", Number: 67},
+		},
+		{
+			name: "owner repo number",
+			raw:  "Patient-Driven-Care/cortex#67",
+			want: dispatchPRTarget{Owner: "Patient-Driven-Care", Repo: "cortex", Number: 67},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := resolveDispatchPRTarget(tc.raw)
+			if err != nil {
+				t.Fatalf("expected parse to succeed: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("expected %#v, got %#v", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestResolveDispatchPRTargetUsesCurrentRepoForNumber(t *testing.T) {
+	previous := dispatchCurrentRepoResolver
+	dispatchCurrentRepoResolver = func() (string, string, error) {
+		return "Patient-Driven-Care", "cortex", nil
+	}
+	defer func() {
+		dispatchCurrentRepoResolver = previous
+	}()
+
+	got, err := resolveDispatchPRTarget("67")
+	if err != nil {
+		t.Fatalf("expected current-repo PR number parse to succeed: %v", err)
+	}
+
+	want := dispatchPRTarget{Owner: "Patient-Driven-Care", Repo: "cortex", Number: 67}
+	if got != want {
+		t.Fatalf("expected %#v, got %#v", want, got)
+	}
+}
+
+func TestParseGitHubRemoteURL(t *testing.T) {
+	cases := []struct {
+		raw   string
+		owner string
+		repo  string
+	}{
+		{raw: "git@github.com:jamesonstone/kit.git", owner: "jamesonstone", repo: "kit"},
+		{raw: "https://github.com/Patient-Driven-Care/cortex.git", owner: "Patient-Driven-Care", repo: "cortex"},
+		{raw: "ssh://git@github.com/Patient-Driven-Care/cortex.git", owner: "Patient-Driven-Care", repo: "cortex"},
+	}
+
+	for _, tc := range cases {
+		owner, repo, err := parseGitHubRemoteURL(tc.raw)
+		if err != nil {
+			t.Fatalf("expected %q to parse: %v", tc.raw, err)
+		}
+		if owner != tc.owner || repo != tc.repo {
+			t.Fatalf("expected %s/%s, got %s/%s", tc.owner, tc.repo, owner, repo)
+		}
+	}
+}
+
+func TestBuildDispatchPRInputFiltersExtractsAndDedupes(t *testing.T) {
+	threads := []dispatchGitHubReviewThread{
+		reviewThreadFixture("internal/app.go", 12, false, false, "coderabbitai", coderabbitCommentBody("Fix app routing."), "https://example.com/1"),
+		reviewThreadFixture("internal/app.go", 12, false, false, "coderabbitai", coderabbitCommentBody("Fix app routing."), "https://example.com/duplicate"),
+		reviewThreadFixture("internal/stale.go", 2, true, false, "coderabbitai", coderabbitCommentBody("Skip resolved."), "https://example.com/2"),
+		reviewThreadFixture("internal/old.go", 3, false, true, "coderabbitai", coderabbitCommentBody("Skip outdated."), "https://example.com/3"),
+		reviewThreadFixture("internal/human.go", 4, false, false, "octocat", "Please update the docs.\n\n<!-- fingerprinting:test -->", "https://example.com/4"),
+	}
+
+	input := buildDispatchPRInput(threads, false)
+	if input.CommonReviewInstruction != coderabbitSharedReviewInstruction {
+		t.Fatalf("expected shared CodeRabbit instruction once, got %q", input.CommonReviewInstruction)
+	}
+	if strings.Count(input.RawTasks, "Fix app routing.") != 1 {
+		t.Fatalf("expected duplicate CodeRabbit prompt to be collapsed, got %q", input.RawTasks)
+	}
+	if strings.Contains(input.RawTasks, "Verify each finding") {
+		t.Fatalf("expected repeated boilerplate to be stripped from task bodies: %q", input.RawTasks)
+	}
+	if strings.Contains(input.RawTasks, "Skip resolved") || strings.Contains(input.RawTasks, "Skip outdated") {
+		t.Fatalf("expected resolved/outdated threads to be filtered: %q", input.RawTasks)
+	}
+	if !strings.Contains(input.RawTasks, "Please update the docs.") {
+		t.Fatalf("expected non-CodeRabbit review task to be included: %q", input.RawTasks)
+	}
+
+	coderabbitInput := buildDispatchPRInput(threads, true)
+	if strings.Contains(coderabbitInput.RawTasks, "Please update the docs.") {
+		t.Fatalf("expected --coderabbit input to exclude non-CodeRabbit authors: %q", coderabbitInput.RawTasks)
+	}
+}
+
+func TestSplitDispatchPRInputFromEditorKeepsInstructionOutOfTasks(t *testing.T) {
+	raw := strings.Join([]string{
+		coderabbitSharedReviewInstruction,
+		"",
+		"- Source: internal/app.go:12",
+		"  Review task:",
+		"  Fix app routing.",
+	}, "\n")
+
+	tasks, instruction := splitDispatchPRInputFromEditor(raw, coderabbitSharedReviewInstruction)
+	if instruction != coderabbitSharedReviewInstruction {
+		t.Fatalf("expected common instruction to be preserved, got %q", instruction)
+	}
+	if strings.Contains(tasks, "Verify each finding") {
+		t.Fatalf("expected tasks to omit common instruction, got %q", tasks)
+	}
+	if !strings.Contains(tasks, "Fix app routing.") {
+		t.Fatalf("expected review task body, got %q", tasks)
+	}
+}
+
 func TestResolveDispatchInputSourcePrecedence(t *testing.T) {
 	if got := resolveDispatchInputSource("tasks.md", false); got != dispatchInputSourceFile {
 		t.Fatalf("expected --file to win, got %s", got)
@@ -106,6 +263,65 @@ func TestResolveDispatchInputSourcePrecedence(t *testing.T) {
 	if got := resolveDispatchInputSource("", true); got != dispatchInputSourceEditor {
 		t.Fatalf("expected editor source, got %s", got)
 	}
+}
+
+func TestDispatchCommandExposesPRFlags(t *testing.T) {
+	dispatch, _, err := rootCmd.Find([]string{"dispatch"})
+	if err != nil {
+		t.Fatalf("rootCmd.Find(dispatch) error = %v", err)
+	}
+	if dispatch.Flags().Lookup("pr") == nil {
+		t.Fatal("expected dispatch to expose --pr")
+	}
+	if dispatch.Flags().Lookup("coderabbit") == nil {
+		t.Fatal("expected dispatch to expose --coderabbit")
+	}
+}
+
+func reviewThreadFixture(
+	path string,
+	line int,
+	resolved bool,
+	outdated bool,
+	author string,
+	body string,
+	url string,
+) dispatchGitHubReviewThread {
+	thread := dispatchGitHubReviewThread{
+		IsResolved: resolved,
+		IsOutdated: outdated,
+		Path:       path,
+		Line:       line,
+	}
+	thread.Comments.Nodes = []dispatchGitHubReviewComment{
+		{
+			Body: body,
+			URL:  url,
+		},
+	}
+	thread.Comments.Nodes[0].Author.Login = author
+	return thread
+}
+
+func coderabbitCommentBody(task string) string {
+	return strings.Join([]string{
+		"_⚠️ Potential issue_ | _🟠 Major_ | _⚡ Quick win_",
+		"",
+		"**Finding title**",
+		"",
+		"<details>",
+		"<summary>🤖 Prompt for AI Agents</summary>",
+		"",
+		"```",
+		coderabbitSharedReviewInstruction,
+		"",
+		task,
+		"```",
+		"",
+		"</details>",
+		"",
+		"<!-- fingerprinting:test -->",
+	}, "\n")
 }
 
 func TestValidateDispatchMaxSubagents(t *testing.T) {

--- a/pkg/cli/editor_input.go
+++ b/pkg/cli/editor_input.go
@@ -142,6 +142,16 @@ func resolveExactEditorCommand(editor string) ([]string, error) {
 }
 
 func readEditorText(inputCfg freeTextInputConfig, fieldName string, emptyAllowed bool) (string, error) {
+	return readEditorTextWithInitialContent(inputCfg, fieldName, "", emptyAllowed, true)
+}
+
+func readEditorTextWithInitialContent(
+	inputCfg freeTextInputConfig,
+	fieldName string,
+	initialContent string,
+	emptyAllowed bool,
+	requireChange bool,
+) (string, error) {
 	cancelAction := "cancel"
 	if emptyAllowed {
 		cancelAction = "skip"
@@ -153,12 +163,12 @@ func readEditorText(inputCfg freeTextInputConfig, fieldName string, emptyAllowed
 		return "", err
 	}
 
-	text, changed, err := editorInputRunner(inputCfg, fieldName, "")
+	text, changed, err := editorInputRunner(inputCfg, fieldName, initialContent)
 	if err != nil {
 		return "", err
 	}
 
-	if !changed {
+	if !changed && requireChange {
 		if emptyAllowed {
 			return "", nil
 		}

--- a/pkg/cli/prompt_builtin_render.go
+++ b/pkg/cli/prompt_builtin_render.go
@@ -196,7 +196,7 @@ func renderSupportDispatchPrompt() (string, error) {
 		return "", fmt.Errorf("failed to get working directory: %w", err)
 	}
 
-	prompt := buildDispatchPrompt(tasks, 10, workingDirectory, dispatchInputSourceEditor)
+	prompt := buildDispatchPrompt(tasks, 10, workingDirectory, dispatchInputSourceEditor, dispatchPromptOptions{})
 	return preparePromptWithoutSubagents(prompt), nil
 }
 


### PR DESCRIPTION
## Description

- :sparkles: Adds `kit dispatch --pr <url|number>` to import unresolved, non-outdated GitHub PR review threads into the dispatch editor.
- :mag: Resolves PR targets from GitHub URLs, Markdown links, `owner/repo#number`, or current-repository PR numbers from the `origin` remote.
- :robot: Adds `--coderabbit` filtering, extracts CodeRabbit `Prompt for AI Agents` blocks, strips repeated boilerplate into one common review instruction, and falls back to cleaned review comment text when no prompt block exists.
- :recycle: Reuses the existing dispatch editor and prompt pipeline so fetched review tasks still go through the normal overlap-clustering workflow.
- :white_check_mark: Adds focused coverage for parsing, filtering, prompt extraction, deduplication, common instruction handling, and command flag visibility.
- :memo: Documents the new PR review import behavior in the dispatch spec and README.

## How to Test

1. `go test ./pkg/cli -run 'Test(BuildDispatch|NormalizeDispatch|ResolveDispatch|ParseGitHubRemote|SplitDispatch|DispatchCommand|ValidateDispatch|FinalizeEditor|ReadEditor)'`
2. `go test ./...`
3. `go run ./cmd/kit check --project`
4. `git diff --check`
5. `go run ./cmd/kit dispatch --help`
6. `EDITOR=true go run ./cmd/kit dispatch --pr='[Patient-Driven-Care/cortex#67](https://github.com/Patient-Driven-Care/cortex/pull/67)' --coderabbit --output-only`
7. Focused secret scan for common token/private key patterns across changed files

## Ticket

Closes #7
