### PR TITLE
fix(GH-20): :bug: fix root help workflow rendering

### DIFF
--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -11,19 +11,9 @@ import (
 var Version = "dev"
 
 var rootCmd = &cobra.Command{
-	Use:   "kit",
-	Short: "🧰 Kit v2 is a general-purpose harness for thought work",
-	Long: banner() + `
-Kit v2 is a general-purpose harness for disciplined thought work.
-Its strongest engine is a document-first, spec-driven workflow, but the
-harness also supports ad hoc execution, catch-up, handoff, summarization,
-review, and orchestration.
-
-The current command surface is packaged around repository and software
-workflows, but the underlying harness patterns generalize to research,
-strategy, operations, writing, policy, and other structured fields.
-
-` + flowDiagram(),
+	Use:     "kit",
+	Short:   "🧰 Kit v2 is a general-purpose harness for thought work",
+	Long:    rootLong(humanOutputStyle{}),
 	Version: Version,
 }
 

--- a/pkg/cli/root_banner.go
+++ b/pkg/cli/root_banner.go
@@ -16,7 +16,21 @@ const (
 	reflect      = "\033[38;5;141m"
 )
 
-func banner() string {
+func rootLong(style humanOutputStyle) string {
+	return rootBanner(style) + `
+Kit v2 is a general-purpose harness for disciplined thought work.
+Its strongest engine is a document-first, spec-driven workflow, but the
+harness also supports ad hoc execution, catch-up, handoff, summarization,
+review, and orchestration.
+
+The current command surface is packaged around repository and software
+workflows, but the underlying harness patterns generalize to research,
+strategy, operations, writing, policy, and other structured fields.
+
+` + flowDiagram(style)
+}
+
+func rootBanner(style humanOutputStyle) string {
 	colors := []string{
 		"\033[38;5;213m",
 		"\033[38;5;177m",
@@ -37,32 +51,76 @@ func banner() string {
 
 	var result string
 	for i, line := range lines {
-		result += "                                        " + colors[i] + line + reset + "\n"
+		result += "                                        " + rootColor(style, colors[i], line) + "\n"
 	}
 	result += "\n"
-	result += "                                      " + dim + "Kit v2 Thought-Work Harness" + reset + "\n"
+	result += "                                      " + rootMuted(style, "Kit v2 Thought-Work Harness") + "\n"
 	return result
 }
 
-func flowDiagram() string {
+func flowDiagram(style humanOutputStyle) string {
+	idea := rootColor(style, brainstorm, "Idea")
+	specCommand := rootColor(style, spec, "kit spec <feature>")
+	clarify := rootColor(style, brainstorm, "Clarifying Loop")
+	planLane := rootColor(style, plan, "Supervisor + Agent Team Plan")
+	implementLane := rootColor(style, implement, "Subagent Implementation")
+	reflectLane := rootColor(style, reflect, "Subagent Reflection")
+	validateLane := rootColor(style, tasks, "Subagent Validation / Verification")
+	evidence := rootColor(style, constitution, "Evidence + Delivery Gate")
+
 	lines := []string{
-		whiteBold + "🧱 Project Initialization" + reset + dim + " (run once, update as needed):" + reset,
-		gray + "┌──────────────┐" + reset,
-		gray + "│ " + constitution + "Constitution" + reset + gray + " │  ← " + reset + dim + "global constraints, principles, priors" + reset,
-		gray + "└──────────────┘" + reset,
+		rootHeading(style, "🧱 Project Initialization") + rootMuted(style, " (run once, update as needed):"),
+		rootColor(style, gray, "┌──────────────┐"),
+		rootColor(style, gray, "│ ") + rootColor(style, constitution, "Constitution") + rootColor(style, gray, " │  ← ") + rootMuted(style, "global constraints, principles, priors"),
+		rootColor(style, gray, "└──────────────┘"),
 		"",
-		whiteBold + "🔁 V2 Feature Workflow" + reset + dim + " (default):" + reset,
-		gray + "┌──────────────┐    ┌───────────────────────────────────────────────────────────────┐" + reset,
-		gray + "│ " + brainstorm + "Idea / Input" + reset + gray + " │ ─▶ │ " + spec + "kit spec <feature>" + reset + gray + "                                           │" + reset,
-		gray + "└──────────────┘    │ " + spec + "SPEC.md" + reset + gray + ": clarify → ready → implement → validate → reflect → deliver │" + reset,
-		gray + "                    └───────────────────────────────────────────────────────────────┘" + reset,
+		rootHeading(style, "🔁 V2 Feature Workflow") + rootMuted(style, " (default):"),
+		"  " + idea + rootMuted(style, " / input"),
+		"    " + rootArrow(style),
+		"  " + specCommand + rootMuted(style, " creates/updates one durable SPEC.md"),
+		"    " + rootArrow(style),
+		"  " + clarify + rootMuted(style, " → questions, source map, binary acceptance criteria"),
+		"    " + rootArrow(style),
+		"  " + planLane + rootMuted(style, " → supervisor owns scope, lanes, touched files"),
+		"    " + rootArrow(style),
+		"  " + implementLane,
+		"    " + rootArrow(style),
+		"  " + reflectLane,
+		"    " + rootArrow(style),
+		"  " + validateLane + rootMuted(style, " → each criterion proved or routed back"),
+		"    " + rootArrow(style),
+		"  " + evidence + rootMuted(style, " → SPEC.md evidence, docs sync, complete"),
 		"",
-		whiteBold + "🗂️ Durable Artifacts" + reset,
-		"  1. " + constitution + "CONSTITUTION.md" + reset + dim + " — project contract and invariants" + reset,
-		"  2. " + spec + "SPEC.md" + reset + dim + "         — v2 feature artifact: thesis, context, clarifications, requirements, assumptions," + reset,
-		dim + "                    acceptance criteria, plan, task checklist, validation map, reflection, docs, delivery, evidence" + reset,
-		"  3. " + brainstorm + "BRAINSTORM/PLAN/TASKS" + reset + dim + " — legacy v1 staged artifacts, preserved as historical context when present" + reset,
+		rootHeading(style, "🗂️ Durable Artifacts"),
+		"  1. " + rootColor(style, constitution, "CONSTITUTION.md") + rootMuted(style, " — project contract and invariants"),
+		"  2. " + rootColor(style, spec, "SPEC.md") + rootMuted(style, "         — v2 feature artifact and workflow state"),
+		"  3. " + rootColor(style, brainstorm, "BRAINSTORM/PLAN/TASKS") + rootMuted(style, " — legacy v1 artifacts, historical unless using kit legacy"),
 	}
 
 	return strings.Join(lines, "\n")
+}
+
+func rootHeading(style humanOutputStyle, text string) string {
+	if !style.enabled {
+		return text
+	}
+	return whiteBold + text + reset
+}
+
+func rootMuted(style humanOutputStyle, text string) string {
+	if !style.enabled {
+		return text
+	}
+	return dim + text + reset
+}
+
+func rootColor(style humanOutputStyle, color string, text string) string {
+	if !style.enabled {
+		return text
+	}
+	return color + text + reset
+}
+
+func rootArrow(style humanOutputStyle) string {
+	return rootColor(style, gray, "│") + "\n    " + rootColor(style, gray, "▼")
 }

--- a/pkg/cli/root_help.go
+++ b/pkg/cli/root_help.go
@@ -118,7 +118,7 @@ func renderRootHelp(cmd *cobra.Command) error {
 	out := cmd.OutOrStdout()
 	style := styleForWriter(out)
 
-	if _, err := fmt.Fprintln(out, strings.TrimRight(cmd.Long, "\n")); err != nil {
+	if _, err := fmt.Fprintln(out, strings.TrimRight(rootLong(style), "\n")); err != nil {
 		return err
 	}
 

--- a/pkg/cli/root_help_test.go
+++ b/pkg/cli/root_help_test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"bytes"
+	"io"
 	"regexp"
 	"strings"
 	"testing"
@@ -27,7 +28,12 @@ func TestRootHelpGroupsCanonicalCommands(t *testing.T) {
 		t.Fatalf("rootCmd.Execute() error = %v", err)
 	}
 
-	content := stripANSI(out.String())
+	raw := out.String()
+	if ansiEscapeRE.MatchString(raw) {
+		t.Fatalf("expected non-terminal root help to omit ANSI escapes, got %q", raw)
+	}
+
+	content := stripANSI(raw)
 	checks := []string{
 		"Setup",
 		"Workflow",
@@ -36,10 +42,18 @@ func TestRootHelpGroupsCanonicalCommands(t *testing.T) {
 		"Utilities",
 		"V2 Feature Workflow",
 		"kit spec <feature>",
-		"SPEC.md: clarify",
+		"Idea / input",
+		"Clarifying Loop",
+		"source map",
+		"binary acceptance criteria",
+		"Supervisor + Agent Team Plan",
+		"Subagent Implementation",
+		"Subagent Reflection",
+		"Subagent Validation / Verification",
+		"Evidence + Delivery Gate",
 		"Durable Artifacts",
 		"v2 feature artifact",
-		"legacy v1 staged artifacts",
+		"legacy v1 artifacts",
 		"legacy",
 		"List deprecated v1 staged workflow commands",
 		"scaffold",
@@ -91,6 +105,52 @@ func TestRootHelpGroupsCanonicalCommands(t *testing.T) {
 	for _, check := range staleWorkflowChecks {
 		if strings.Contains(content, check) {
 			t.Fatalf("expected root help to omit stale v1 workflow text %q, got %q", check, content)
+		}
+	}
+}
+
+func TestRootNoCommandShowsV2WorkflowDiagram(t *testing.T) {
+	content := stripANSI(executeHelp(t, []string{}))
+
+	checks := []string{
+		"Kit v2 Thought-Work Harness",
+		"Idea / input",
+		"kit spec <feature> creates/updates one durable SPEC.md",
+		"Clarifying Loop",
+		"Subagent Implementation",
+		"Subagent Reflection",
+		"Subagent Validation / Verification",
+		"Evidence + Delivery Gate",
+		"Usage",
+		"Available Commands",
+	}
+	for _, check := range checks {
+		if !strings.Contains(content, check) {
+			t.Fatalf("expected no-command root help to contain %q, got %q", check, content)
+		}
+	}
+}
+
+func TestRootHelpUsesColorForTerminalOutput(t *testing.T) {
+	previousCheck := terminalWriterCheck
+	terminalWriterCheck = func(_ io.Writer) bool { return true }
+	defer func() { terminalWriterCheck = previousCheck }()
+
+	output := executeHelp(t, []string{"--help"})
+	if !ansiEscapeRE.MatchString(output) {
+		t.Fatalf("expected terminal root help to include ANSI color, got %q", output)
+	}
+
+	content := stripANSI(output)
+	for _, check := range []string{
+		"Idea / input",
+		"Clarifying Loop",
+		"Subagent Implementation",
+		"Subagent Reflection",
+		"Subagent Validation / Verification",
+	} {
+		if !strings.Contains(content, check) {
+			t.Fatalf("expected colored root help to contain %q, got %q", check, content)
 		}
 	}
 }


### PR DESCRIPTION
## Description

- :bug: Fixes root no-command help rendering so captured and piped output no longer includes raw ANSI escape sequences.
- :sparkles: Replaces the wide v2 workflow line with a concise vertical flow: idea, clarifying loop, supervisor/team planning, subagent implementation, subagent reflection, subagent validation/verification, and evidence gate.
- :white_check_mark: Adds regression coverage for no-command help, non-terminal ANSI suppression, and terminal color rendering.

## How to Test

1. :white_check_mark: `go test ./...`
2. :white_check_mark: `git diff --check`
3. :white_check_mark: `git diff --cached --check`
4. :white_check_mark: `go run ./cmd/kit`
5. :white_check_mark: `go run ./cmd/kit --help`
6. :white_check_mark: pre-commit `make build`

## Ticket

Closes #20