### PR TITLE
feat(GH-60): :sparkles: scaffold Makefile during init

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ the complete durable truth.
 
 | Command | Purpose |
 | --- | --- |
-| `kit init` | Initialize or refresh Kit-managed project scaffolding |
+| `kit init` | Initialize or refresh project scaffolding, including a project-owned Makefile starter |
 | `kit spec <feature>` | Non-interactively scaffold, adopt, or orient a living specification |
 | `kit spec <feature> --legacy-supervisor` | Temporarily run the deprecated V2 lifecycle supervisor |
 | `kit loop workflow <feature>` | Deprecated V2 compatibility loop; V3 specs use native planning |

--- a/docs/PROJECT_PROGRESS_SUMMARY.md
+++ b/docs/PROJECT_PROGRESS_SUMMARY.md
@@ -44,6 +44,7 @@
 | 0040 | prompt-system-migration | `docs/specs/0040-prompt-system-migration` | deliver | no | 2026-07-10 | Modernize every generated prompt for GPT-5.6, prove the migration with a truthful deterministic benchmark, and preserve Kit's code-enforced workflow gates. |
 | 0041 | aws-config-schema | `docs/specs/0041-aws-config-schema` | deliver | no | 2026-07-13 | Version Kit project configuration and bind each AWS-enabled project to one STS-verified CLI profile and account with fast automatic checks and interactive repair. |
 | 0042 | native-plan-repository-memory | `docs/specs/0042-native-plan-repository-memory` | complete | no | 2026-07-15 | Recenter Kit as a repository-memory and specification harness: native agent planning owns research, clarification, design, and implementation planning, while Kit ensures that consequential implementation rationale survives in canonical repository documents. |
+| 0043 | init-makefile-scaffold | `docs/specs/0043-init-makefile-scaffold` | complete | no | 2026-07-16 | Make `kit init` establish a safe, canonical Make entrypoint for each project and guide the initialization agent to wire targets such as `make dev` to the repository's real development commands. |
 
 ## PROJECT INTENT
 
@@ -416,6 +417,15 @@ See `docs/CONSTITUTION.md` for project-wide constraints and principles.
 - **OPEN ITEMS**: none
 - **POINTERS**: `docs/specs/0042-native-plan-repository-memory/SPEC.md`
 
+### init-makefile-scaffold
+
+- **STATUS**: complete
+- **PAUSED**: no
+- **INTENT**: Make `kit init` establish a safe, canonical Make entrypoint for each project and guide the initialization agent to wire targets such as `make dev` to the repository's real development commands.
+- **APPROACH**: 1. Add a minimal Makefile template with a default `help` target and no unverified project command recipes. 2. Add `Makefile` to fresh init and missing-file refresh scaffolding, with an explicit project-owned preservation rule that wins over targeted force refresh. 3. Expand the generated initialization prompt and visible next steps so an agent maps applicable canonical targets to verified repository-native commands and validates the resulting entrypoints. 4. Add focused template, init, refresh, preservation, and prompt regression tests. 5. Update the core initialization contract and project rollup, then run focused tests, formatting, full Go checks, lint, Kit document validation, and diff review.
+- **OPEN ITEMS**: none
+- **POINTERS**: `docs/specs/0043-init-makefile-scaffold/SPEC.md`
+
 ## LAST UPDATED
 
-2026-07-15 12:43:24 EDT
+2026-07-16 16:09:19 EDT

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -51,7 +51,7 @@ kit rm my-feature --yes --notes
 
 | Command | Description |
 | --- | --- |
-| `kit init` | Initialize project, user config, local env files, `.gitignore`, review config, GitHub PR template, managed README badges and Maintainers section, and optional auto-assignment workflow. |
+| `kit init` | Initialize project, user config, local env files, `.gitignore`, a project-owned Makefile starter, review config, GitHub PR template, managed README badges and Maintainers section, and optional auto-assignment workflow. |
 | `kit scaffold` | Create empty workflow document structures, support directories, and agent files. |
 
 ## Workflow
@@ -224,8 +224,11 @@ to wait up to the timeout.
 
 ## Output Behavior
 
-Prompt-producing commands, including the constitution prompt emitted by
-`kit init`, copy generated output to the clipboard by default.
+Prompt-producing commands, including the Constitution and Makefile setup prompt
+emitted by `kit init`, copy generated output to the clipboard by default. The
+init prompt maps applicable targets such as `make dev`, `make test`, and
+`make check` to verified repository-native commands; it does not leave guessed
+or placeholder recipes in the project-owned Makefile.
 
 Use:
 

--- a/docs/specs/0000_INIT_PROJECT.md
+++ b/docs/specs/0000_INIT_PROJECT.md
@@ -495,6 +495,8 @@ CLI flags always override `.kit.yaml`.
 - create or populate `~/.config/kit/.kit.yaml` with missing default fields
 - create blank `.env` and default `.envrc` if missing
 - include `.env` and `.envrc` in `.gitignore`
+- create a safe starter `Makefile` if missing, with a default help entrypoint and
+  no guessed project commands
 - create `.coderabbit.yaml` if missing
 - create `.github/pull_request_template.md` if missing
 - create `.github/workflows/auto-assign.yml` if missing, using project-local
@@ -511,9 +513,13 @@ CLI flags always override `.kit.yaml`.
 - create `docs/CONSTITUTION.md` if missing
 - scaffold configured agent instruction files and `.github/copilot-instructions.md`
 - if files exist, preserve them; Kit-managed markdown documents may merge missing required sections
-- output a prepared prompt for drafting `docs/CONSTITUTION.md`
+- treat a populated `Makefile` as project-owned and preserve it during normal,
+  full-force, and targeted-force refreshes
+- output a prepared prompt for drafting `docs/CONSTITUTION.md` and populating the
+  starter `Makefile` with thin wrappers over verified repository-native commands
 - by default, copy that prompt to the clipboard instead of printing the prompt body
-- make the first visible next step: paste the copied prompt into the agent to draft `docs/CONSTITUTION.md`
+- make the first visible next step: paste the copied prompt into the agent to
+  populate `Makefile` and draft `docs/CONSTITUTION.md`
 - support `--output-only` to print the raw prompt to stdout instead of copying it
 - support `--copy` to also copy the prompt when `--output-only` is set
 - support `--refresh` as the existing-project structural refresh mode for Kit-managed files
@@ -526,6 +532,8 @@ CLI flags always override `.kit.yaml`.
   clipboard so an agent can update `docs/CONSTITUTION.md`, agent docs,
   references, command docs, and directly affected feature specs semantically
 - support `--refresh --file=<path> --force` for targeted per-file scaffold overwrites
+- support `--refresh --file=Makefile` for missing-file backfill while preserving
+  existing project-owned content even when `--force` is present
 
 ---
 
@@ -1198,7 +1206,7 @@ Findings:
 
 - missing `.gitignore` or missing current Kit-managed `.gitignore` entries
 - missing local init scaffold artifacts such as `.env` or `.envrc`
-- missing tracked init scaffold artifacts such as `.coderabbit.yaml`, `.github/pull_request_template.md`, or `.github/workflows/auto-assign.yml`
+- missing tracked init scaffold artifacts such as `Makefile`, `.coderabbit.yaml`, `.github/pull_request_template.md`, or `.github/workflows/auto-assign.yml`
 - missing required docs or sections
 - placeholder-only required sections
 - malformed `SKILLS`, `DEPENDENCIES`, or `PROGRESS TABLE` tables

--- a/docs/specs/0043-init-makefile-scaffold/SPEC.md
+++ b/docs/specs/0043-init-makefile-scaffold/SPEC.md
@@ -1,0 +1,141 @@
+---
+kit_metadata_version: 1
+artifact: spec
+workflow_version: 3
+phase: complete
+feature:
+  id: 0043
+  slug: init-makefile-scaffold
+  dir: 0043-init-makefile-scaffold
+references:
+  - id: core-init-contract
+    name: Core project initialization contract
+    type: doc
+    target: docs/specs/0000_INIT_PROJECT.md
+    relation: constrains
+    read_policy: must
+    used_for: canonical kit init and refresh behavior
+    status: active
+  - id: init-command
+    name: Init command
+    type: code
+    target: pkg/cli/init.go
+    selector_type: symbol
+    selector: runInit
+    relation: implements
+    read_policy: must
+    used_for: fresh initialization and generated initialization prompt
+    status: active
+  - id: init-scaffold
+    name: Init scaffold files
+    type: code
+    target: pkg/cli/init_scaffold.go
+    relation: implements
+    read_policy: must
+    used_for: create-if-missing project files
+    status: active
+  - id: init-refresh-files
+    name: Init refresh file planning
+    type: code
+    target: pkg/cli/init_refresh_files.go
+    selector_type: symbol
+    selector: planRefreshInitScaffoldFiles
+    relation: implements
+    read_policy: must
+    used_for: missing-file refresh and existing-file preservation
+    status: active
+  - id: project-templates
+    name: Project scaffold templates
+    type: code
+    target: internal/templates/templates.go
+    relation: implements
+    read_policy: must
+    used_for: safe starter Makefile content
+    status: active
+delivery_intent: issue_branch_pr_in_progress
+---
+# SPEC
+
+## PURPOSE
+
+Make `kit init` establish a safe, canonical Make entrypoint for each project and guide the initialization agent to wire targets such as `make dev` to the repository's real development commands.
+
+## CONTEXT
+
+- Fresh initialization already creates project configuration, local environment files, GitHub templates, repository instructions, and a Constitution before emitting a coding-agent prompt.
+- The prompt currently asks only for `docs/CONSTITUTION.md`; it does not establish a consistent command entrypoint for development, build, test, lint, or validation workflows.
+- The Kit, LabCore UI, and LabCore Makefiles share durable conventions: explicit `.PHONY` declarations, thin recipes over native toolchain commands, overridable tool variables where useful, and project-specific target sets rather than one universal recipe body.
+- `kit init` runs before Kit can reliably infer every repository's package manager, runtime, service topology, or local development command. A static template must not pretend guessed commands are valid.
+- Once the initialization agent maps the starter to real commands, the Makefile is project-owned. `kit init --refresh`, including targeted force refreshes, must not erase those commands.
+- Issue `#60` is the delivery source, and branch `GH-60` was created from refreshed `origin/main` before implementation edits.
+
+## REQUIREMENTS
+
+- A fresh `kit init` creates `Makefile` when it is missing and preserves any existing Makefile byte-for-byte.
+- `kit init --refresh` backfills a missing Makefile, while existing Makefiles remain preserved even with `--refresh --file=Makefile --force`.
+- The starter Makefile provides a valid, useful basic structure without placeholder recipes or guessed project commands.
+- The starter uses canonical Make conventions, including a default help entrypoint and explicit `.PHONY` declaration.
+- The initialization prompt instructs the agent to inspect package scripts, toolchain configuration, development docs, and existing automation before adding recipes.
+- The prompt requires canonical targets such as `dev`, `build`, `test`, `check`, `lint`, `fmt`, and `clean` only when a verified underlying repository command or workflow exists; `make dev` is the preferred local-development entrypoint when the project has a development/run workflow.
+- Recipes remain thin wrappers around real project-native commands, composite targets reuse atomic targets, and no TODO, echo-only placeholder, guessed command, or duplicate build logic remains after initialization.
+- Init help, next-step output, focused tests, the core initialization contract, and the project rollup describe the Makefile behavior accurately.
+- Observable acceptance: fresh init and refresh tests create the starter, preservation tests protect customized content, prompt tests assert command-mapping guidance, full Go validation passes, and Kit document checks introduce no blocking finding.
+- Non-goals: modifying sibling repositories, implementing toolchain auto-detection in Kit, forcing one target set on every project, or treating populated Makefiles as Kit-generated files that force refresh may overwrite.
+
+## ACCEPTED PLAN
+
+1. Add a minimal Makefile template with a default `help` target and no unverified project command recipes.
+2. Add `Makefile` to fresh init and missing-file refresh scaffolding, with an explicit project-owned preservation rule that wins over targeted force refresh.
+3. Expand the generated initialization prompt and visible next steps so an agent maps applicable canonical targets to verified repository-native commands and validates the resulting entrypoints.
+4. Add focused template, init, refresh, preservation, and prompt regression tests.
+5. Update the core initialization contract and project rollup, then run focused tests, formatting, full Go checks, lint, Kit document validation, and diff review.
+
+## DECISIONS
+
+- Use a safe `help`-only starter instead of guessed `dev`, build, or test recipes. The initialization prompt owns repository-specific command mapping because it can inspect live project context.
+- Treat the populated Makefile as project-owned. Refresh may create it when absent but may never overwrite an existing file, including under targeted `--force`.
+- Keep Make recipes as thin command aliases. The Makefile is a stable human interface, not a second implementation of package scripts, build pipelines, or service orchestration.
+- Update the existing core init contract as canonical product documentation while retaining this feature spec for the rationale behind starter safety and refresh ownership.
+
+## DISCOVERIES
+
+- Plain `kit spec init-makefile-scaffold --output-only` still entered the deprecated V2 editor flow in this checkout, created a V2 skeleton, and then failed because configured editor `nvim` was unavailable. The generated artifact was semantically converted to this V3 spec before implementation.
+- Targeted refresh validation uses a separate known-target registry from the scaffold planner. The first focused test run exposed the missing `Makefile` registration; adding it made targeted create and preserve behavior reachable.
+- The documented `kit rollup` command is not available in the current CLI. V3 completion is the supported path that refreshes `PROJECT_PROGRESS_SUMMARY.md` after the living spec is complete.
+- GitHub reports no explicit branch-protection resource for `main`; repository safety rules therefore require treating `main` as protected by assumption.
+- The shell's default `PATH` omits `gh` and `go`; the installed `/opt/homebrew/bin/gh` and `/opt/homebrew/bin/go` binaries are the verified command paths for this task.
+
+## VALIDATION
+
+- Focused template, fresh-init, refresh, force-preservation, and prompt tests passed in `internal/templates` and `pkg/cli`.
+- Full affected-package tests passed: `go test ./internal/templates ./pkg/cli -count=1`.
+- A built Kit binary initialized a temporary project successfully; the generated starter ran `make help`, and the emitted prompt contained the absolute Makefile path, verified-command requirement, `make dev` guidance, and placeholder prohibition.
+- `PATH="/opt/homebrew/bin:$PATH" make fmt` passed.
+- `go test ./... -count=1` passed across all packages.
+- `go vet ./...` and `go build ./cmd/kit` passed.
+- `go test -race ./internal/templates ./pkg/cli -count=1` passed.
+- `PATH="/opt/homebrew/bin:$PATH" golangci-lint run --new-from-rev=origin/main ./...` passed with `0 issues`.
+- `go run ./cmd/kit check 0043-init-makefile-scaffold` passed.
+- Initial `go run ./cmd/kit check --project` reported only the expected blocking absence of the new 0043 rollup row and heading, plus historical compatibility warnings and the existing Constitution-refresh advisory. V3 completion will refresh the rollup before the final project check.
+- `go run ./cmd/kit complete 0043-init-makefile-scaffold` passed, set the V3 phase to `complete`, and refreshed `docs/PROJECT_PROGRESS_SUMMARY.md` with the 0043 row and summary.
+- Final `go run ./cmd/kit check --project` exited successfully with 15 non-blocking historical V2 compatibility advisories and the existing project-refresh advisory; it reported no blocking findings attributable to this feature.
+- `git diff --check` passed before completion curation; final staged and unstaged whitespace checks remain part of delivery validation.
+
+## OUTCOME
+
+- Fresh `kit init` now creates a safe Makefile starter with `.DEFAULT_GOAL := help` and `.PHONY: help` while preserving existing Makefiles byte-for-byte.
+- Full and targeted refreshes backfill a missing Makefile, but existing project-owned content wins over targeted `--force` refresh.
+- The initialization prompt now inspects repository-native command sources, exposes `make dev` when a verified development workflow exists, adds only applicable canonical targets, keeps recipes thin, rejects placeholders and guessed commands, and requires safe target validation.
+- Init help, next steps, README, command guidance, the core initialization contract, focused tests, and this rationale record are aligned with the shipped behavior.
+- No sibling repository was modified; its Makefile remained a read-only canonical example.
+
+## REPOSITORY MEMORY
+
+Decision: updated
+
+Rationale: The code and tests can preserve scaffold mechanics, but they cannot fully preserve why the starter avoids guessed commands or why force refresh must yield to project ownership. This feature spec records that rationale, and the core init contract will remain the canonical shipped-behavior reference.
+
+Artifacts:
+
+- `docs/specs/0043-init-makefile-scaffold/SPEC.md`
+- `docs/specs/0000_INIT_PROJECT.md`

--- a/internal/templates/templates.go
+++ b/internal/templates/templates.go
@@ -29,6 +29,19 @@ set -eu
 dotenv_if_exists
 `
 
+// Makefile is the safe starter command surface for repositories initialized
+// with Kit. Project-specific targets are added by the initialization prompt
+// only after their underlying commands have been verified.
+const Makefile = `.DEFAULT_GOAL := help
+
+.PHONY: help
+
+help:
+	@printf '%s\n' 'Project developer workflow'
+	@printf '%s\n' ''
+	@printf '%s\n' 'Run the Kit initialization prompt to add project-specific targets.'
+`
+
 // Constitution template per spec section 6.1
 const Constitution = `# CONSTITUTION
 

--- a/internal/templates/templates_test.go
+++ b/internal/templates/templates_test.go
@@ -111,6 +111,25 @@ func TestBuildAutoAssignWorkflowNoOpsWithoutAssignees(t *testing.T) {
 	}
 }
 
+func TestMakefileTemplateProvidesSafeStarter(t *testing.T) {
+	for _, check := range []string{
+		".DEFAULT_GOAL := help",
+		".PHONY: help",
+		"help:",
+		"Run the Kit initialization prompt to add project-specific targets.",
+	} {
+		if !strings.Contains(Makefile, check) {
+			t.Fatalf("expected Makefile template to contain %q, got:\n%s", check, Makefile)
+		}
+	}
+
+	for _, unverified := range []string{"TODO", "dev:", "npm ", "go run ", "docker compose"} {
+		if strings.Contains(Makefile, unverified) {
+			t.Fatalf("Makefile template must not contain unverified command %q:\n%s", unverified, Makefile)
+		}
+	}
+}
+
 func TestFeatureArtifactBuildersDoNotDuplicateCanonicalBodyTables(t *testing.T) {
 	featureMeta := document.FeatureMetadataFromDir("0001-sample-feature")
 	for name, content := range map[string]string{

--- a/pkg/cli/init.go
+++ b/pkg/cli/init.go
@@ -30,6 +30,7 @@ Creates:
   - .kit.yaml configuration file
   - .gitignore entries for Kit-local environment and generated artifacts
   - .env and .envrc local environment files
+  - Makefile starter for canonical project commands
   - .coderabbit.yaml review configuration file
   - .github/pull_request_template.md pull request template
   - .github/workflows/auto-assign.yml issue and pull request assignment workflow
@@ -43,7 +44,7 @@ If files already exist, Kit preserves them. Kit-managed markdown documents may
 be merged by adding missing required sections.
 
 Modes:
-  Default:        Copy the prepared CONSTITUTION.md prompt to the clipboard and show next steps
+  Default:        Copy the prepared project initialization prompt to the clipboard and show next steps
   --refresh:      Refresh Kit-managed project files for an existing Kit project
 
 Flags:
@@ -158,6 +159,9 @@ func runInit(cmd *cobra.Command, args []string) error {
 	if err := scaffoldGitignore(cwd, initOutputOnly); err != nil {
 		return err
 	}
+	if err := scaffoldMakefile(cwd, initOutputOnly); err != nil {
+		return err
+	}
 	if err := scaffoldEnvFiles(cwd, initOutputOnly); err != nil {
 		return err
 	}
@@ -252,8 +256,8 @@ func runInit(cmd *cobra.Command, args []string) error {
 
 	if !initOutputOnly {
 		printNumberedNextSteps([]string{
-			"Paste the copied prompt into your agent to draft docs/CONSTITUTION.md",
-			"Review and refine docs/CONSTITUTION.md to define project constraints",
+			"Paste the copied prompt into your agent to populate Makefile and draft docs/CONSTITUTION.md",
+			"Review the project commands and docs/CONSTITUTION.md, then run the applicable Make targets",
 			"Run `kit spec <feature-name>` to create your first feature",
 		})
 	}
@@ -286,6 +290,7 @@ func populateGlobalConfig(outputOnly bool) error {
 }
 
 func buildProjectInitPrompt(projectRoot, constitutionFullPath string) string {
+	makefileFullPath := filepath.Join(projectRoot, makefilePath)
 	return renderPromptDocument(func(doc *promptdoc.Document) {
 		doc.Paragraph(fmt.Sprintf(
 			"Please update %s with all patterns, strategy, implementation details, process, and long-term vision for this project.\nThis document will drive the \"rules for development\" going forward.",
@@ -298,6 +303,19 @@ func buildProjectInitPrompt(projectRoot, constitutionFullPath string) string {
 			"Dependencies and their purposes",
 			"Non-negotiable constraints",
 			"Project goals and non-goals",
+		)
+		doc.Paragraph(fmt.Sprintf(
+			"Populate %s with a canonical project command interface backed by this repository's real commands.",
+			makefileFullPath,
+		))
+		doc.BulletList(
+			"Inspect package scripts, toolchain configuration, development documentation, and existing automation before choosing recipe commands",
+			"Expose `make dev` when the repository has a verified local development or run workflow",
+			"Add only applicable canonical targets such as `build`, `test`, `check`, `lint`, `fmt`, and `clean`, plus useful project-specific targets",
+			"Keep recipes as thin wrappers around repository-native commands; let composite targets reuse atomic targets instead of duplicating their commands",
+			"Declare non-file targets with `.PHONY` and use overridable tool variables when they improve portability",
+			"Do not leave TODO recipes, echo-only placeholders, guessed commands, or duplicated build logic",
+			"Run `make help` and each added target that is safe to execute, and report any target that could not be validated",
 		)
 		doc.Paragraph("Rules:")
 		doc.BulletList("PROJECT_PROGRESS_SUMMARY.md must reflect the highest completed artifact per feature at all times")

--- a/pkg/cli/init_refresh.go
+++ b/pkg/cli/init_refresh.go
@@ -207,6 +207,7 @@ func initRefreshKnownTargets(cfg *config.Config, registry []registryRuleset) map
 		gitignorePath:                          true,
 		envPath:                                true,
 		envrcPath:                              true,
+		makefilePath:                           true,
 		codeRabbitConfigPath:                   true,
 		pullRequestTemplatePath:                true,
 		autoAssignWorkflowPath:                 true,

--- a/pkg/cli/init_refresh_file_test.go
+++ b/pkg/cli/init_refresh_file_test.go
@@ -49,6 +49,56 @@ func TestRunInitRefresh_FileForceOverwritesOnlySelectedExistingFile(t *testing.T
 	assertFileDoesNotExist(t, filepath.Join(tempDir, agentsMDPath))
 }
 
+func TestRunInitRefresh_CreatesMissingMakefile(t *testing.T) {
+	tempDir := t.TempDir()
+	setupInitHome(t)
+	setWorkingDirectory(t, tempDir)
+
+	withInitFlags(t, func() {
+		initRefresh = true
+		initOutputOnly = true
+		initRefreshFiles = []string{makefilePath}
+
+		_ = captureStdout(t, func() {
+			if err := runInit(initCmd, nil); err != nil {
+				t.Fatalf("runInit() error = %v", err)
+			}
+		})
+	})
+
+	content := readFile(t, filepath.Join(tempDir, makefilePath))
+	if content != templates.Makefile {
+		t.Fatalf("%s content = %q, want %q", makefilePath, content, templates.Makefile)
+	}
+}
+
+func TestRunInitRefresh_FileForcePreservesExistingMakefile(t *testing.T) {
+	tempDir := t.TempDir()
+	setupInitHome(t)
+	setWorkingDirectory(t, tempDir)
+
+	existing := ".PHONY: dev\n\ndev:\n\tgo run ./cmd/server\n"
+	writeFile(t, filepath.Join(tempDir, makefilePath), existing)
+
+	withInitFlags(t, func() {
+		initRefresh = true
+		initForce = true
+		initOutputOnly = true
+		initRefreshFiles = []string{makefilePath}
+
+		_ = captureStdout(t, func() {
+			if err := runInit(initCmd, nil); err != nil {
+				t.Fatalf("runInit() error = %v", err)
+			}
+		})
+	})
+
+	content := readFile(t, filepath.Join(tempDir, makefilePath))
+	if content != existing {
+		t.Fatalf("%s content = %q, want custom content %q", makefilePath, content, existing)
+	}
+}
+
 func TestRunInitRefresh_ForceDoesNotOverwriteExistingScaffoldFilesWithoutFileTarget(t *testing.T) {
 	tempDir := t.TempDir()
 	setupInitHome(t)

--- a/pkg/cli/init_refresh_files.go
+++ b/pkg/cli/init_refresh_files.go
@@ -19,13 +19,15 @@ func planRefreshInitScaffoldFiles(
 	targets map[string]bool,
 ) ([]initRefreshFileChange, error) {
 	files := []struct {
-		relativePath string
-		content      string
-		merge        bool
+		relativePath     string
+		content          string
+		merge            bool
+		preserveExisting bool
 	}{
 		{relativePath: gitignorePath, content: templates.Gitignore, merge: true},
 		{relativePath: envPath, content: ""},
 		{relativePath: envrcPath, content: templates.Envrc},
+		{relativePath: makefilePath, content: templates.Makefile, preserveExisting: true},
 		{relativePath: codeRabbitConfigPath, content: templates.CodeRabbitConfig},
 		{relativePath: pullRequestTemplatePath, content: templates.PullRequestTemplate},
 	}
@@ -35,7 +37,15 @@ func planRefreshInitScaffoldFiles(
 		if !initRefreshTargetMatches(targets, file.relativePath) {
 			continue
 		}
-		change, err := planRefreshInitScaffoldFile(projectRoot, opts, targets, file.relativePath, file.content, file.merge)
+		change, err := planRefreshInitScaffoldFile(
+			projectRoot,
+			opts,
+			targets,
+			file.relativePath,
+			file.content,
+			file.merge,
+			file.preserveExisting,
+		)
 		if err != nil {
 			return nil, err
 		}
@@ -58,6 +68,7 @@ func planRefreshInitScaffoldFile(
 	relativePath string,
 	content string,
 	merge bool,
+	preserveExisting bool,
 ) (initRefreshFileChange, error) {
 	path := filepath.Join(projectRoot, filepath.FromSlash(relativePath))
 	exists := document.Exists(path)
@@ -72,6 +83,9 @@ func planRefreshInitScaffoldFile(
 		before = string(data)
 	}
 
+	if exists && preserveExisting {
+		return *newInitRefreshFileChange(projectRoot, relativePath, before, before, instructionFileSkipped), nil
+	}
 	if exists && opts.force && explicit {
 		if before == content {
 			return *newInitRefreshFileChange(projectRoot, relativePath, before, before, instructionFileSkipped), nil

--- a/pkg/cli/init_scaffold.go
+++ b/pkg/cli/init_scaffold.go
@@ -14,6 +14,7 @@ import (
 const codeRabbitConfigPath = ".coderabbit.yaml"
 const envPath = ".env"
 const envrcPath = ".envrc"
+const makefilePath = "Makefile"
 const autoAssignWorkflowPath = ".github/workflows/auto-assign.yml"
 const pullRequestTemplatePath = ".github/pull_request_template.md"
 const gitignorePath = ".gitignore"
@@ -98,13 +99,17 @@ func appendGitignorePatterns(content string, patterns []string) string {
 }
 
 func scaffoldEnvFiles(projectRoot string, outputOnly bool) error {
-	if err := scaffoldEnvFile(projectRoot, envPath, "", outputOnly); err != nil {
+	if err := scaffoldFileIfMissing(projectRoot, envPath, "", outputOnly); err != nil {
 		return err
 	}
-	return scaffoldEnvFile(projectRoot, envrcPath, templates.Envrc, outputOnly)
+	return scaffoldFileIfMissing(projectRoot, envrcPath, templates.Envrc, outputOnly)
 }
 
-func scaffoldEnvFile(projectRoot, relativePath, content string, outputOnly bool) error {
+func scaffoldMakefile(projectRoot string, outputOnly bool) error {
+	return scaffoldFileIfMissing(projectRoot, makefilePath, templates.Makefile, outputOnly)
+}
+
+func scaffoldFileIfMissing(projectRoot, relativePath, content string, outputOnly bool) error {
 	path := filepath.Join(projectRoot, relativePath)
 	if document.Exists(path) {
 		if !outputOnly {

--- a/pkg/cli/init_scaffold_test.go
+++ b/pkg/cli/init_scaffold_test.go
@@ -58,6 +58,59 @@ func TestRunInit_CreatesPullRequestTemplate(t *testing.T) {
 	})
 }
 
+func TestRunInit_CreatesMakefileStarter(t *testing.T) {
+	tempDir := t.TempDir()
+	setupInitHome(t)
+	setWorkingDirectory(t, tempDir)
+
+	withInitFlags(t, func() {
+		initOutputOnly = true
+
+		_ = captureStdout(t, func() {
+			if err := runInit(initCmd, nil); err != nil {
+				t.Fatalf("runInit() error = %v", err)
+			}
+		})
+
+		content, err := os.ReadFile(filepath.Join(tempDir, makefilePath))
+		if err != nil {
+			t.Fatalf("expected %s to be created: %v", makefilePath, err)
+		}
+		if string(content) != templates.Makefile {
+			t.Fatalf("%s content = %q, want %q", makefilePath, content, templates.Makefile)
+		}
+	})
+}
+
+func TestRunInit_PreservesExistingMakefile(t *testing.T) {
+	tempDir := t.TempDir()
+	setupInitHome(t)
+	setWorkingDirectory(t, tempDir)
+
+	existing := ".PHONY: dev\n\ndev:\n\tnpm run dev\n"
+	if err := os.WriteFile(filepath.Join(tempDir, makefilePath), []byte(existing), 0644); err != nil {
+		t.Fatalf("failed to seed %s: %v", makefilePath, err)
+	}
+
+	withInitFlags(t, func() {
+		initOutputOnly = true
+
+		_ = captureStdout(t, func() {
+			if err := runInit(initCmd, nil); err != nil {
+				t.Fatalf("runInit() error = %v", err)
+			}
+		})
+
+		content, err := os.ReadFile(filepath.Join(tempDir, makefilePath))
+		if err != nil {
+			t.Fatalf("failed to read %s: %v", makefilePath, err)
+		}
+		if string(content) != existing {
+			t.Fatalf("%s content = %q, want %q", makefilePath, content, existing)
+		}
+	})
+}
+
 func TestRunInit_CreatesGitignoreWithKitLocalArtifacts(t *testing.T) {
 	tempDir := t.TempDir()
 	setupInitHome(t)

--- a/pkg/cli/init_test.go
+++ b/pkg/cli/init_test.go
@@ -40,13 +40,23 @@ func TestRunInit_DefaultCopiesConstitutionPromptAndShowsPasteStep(t *testing.T) 
 		if !strings.Contains(copied, "Please update "+filepath.Join(cwd, constitutionPath)+" with all patterns") {
 			t.Fatalf("expected copied prompt to target %s, got %q", filepath.Join(cwd, constitutionPath), copied)
 		}
+		for _, check := range []string{
+			"Populate " + filepath.Join(cwd, makefilePath) + " with a canonical project command interface",
+			"Expose `make dev` when the repository has a verified local development or run workflow",
+			"Do not leave TODO recipes, echo-only placeholders, guessed commands, or duplicated build logic",
+			"Run `make help` and each added target that is safe to execute",
+		} {
+			if !strings.Contains(copied, check) {
+				t.Fatalf("expected copied prompt to contain %q, got %q", check, copied)
+			}
+		}
 		if strings.Contains(copied, "Copy this section to the Agent:") {
 			t.Fatalf("expected clipboard payload to contain only the prompt body, got %q", copied)
 		}
 		if !strings.Contains(output, "Copied the prepared text to the clipboard.") {
 			t.Fatalf("expected stdout to acknowledge clipboard copy, got %q", output)
 		}
-		if !strings.Contains(output, "1. Paste the copied prompt into your agent to draft docs/CONSTITUTION.md") {
+		if !strings.Contains(output, "1. Paste the copied prompt into your agent to populate Makefile and draft docs/CONSTITUTION.md") {
 			t.Fatalf("expected stdout to include the paste guidance, got %q", output)
 		}
 		if strings.Contains(output, "Please update "+filepath.Join(cwd, constitutionPath)) {


### PR DESCRIPTION
## Description

- :sparkles: Adds a safe help-first `Makefile` starter to fresh `kit init` projects and missing-file refreshes.
- :lock: Preserves populated project-owned Makefiles during normal, full-force, and targeted-force refreshes.
- :wrench: Expands the initialization prompt so applicable targets such as `make dev`, `make test`, and `make check` delegate to verified repository-native commands.
- :white_check_mark: Covers starter creation, existing-file preservation, targeted refresh, force preservation, and prompt guidance.
- :memo: Updates the core init contract, command guidance, README, V3 feature memory, and project rollup.

## How to Test

1. `PATH="/opt/homebrew/bin:$PATH" make fmt`
2. `/opt/homebrew/bin/go test ./... -count=1`
3. `/opt/homebrew/bin/go vet ./...`
4. `/opt/homebrew/bin/go build ./cmd/kit`
5. `/opt/homebrew/bin/go test -race ./internal/templates ./pkg/cli -count=1`
6. `PATH="/opt/homebrew/bin:$PATH" /opt/homebrew/bin/golangci-lint run --new-from-rev=origin/main ./...`
7. `/opt/homebrew/bin/go run ./cmd/kit check 0043-init-makefile-scaffold`
8. `/opt/homebrew/bin/go run ./cmd/kit check --project`
9. Build Kit, run `kit init --output-only` in a temporary project, and verify the generated `Makefile` passes `make help` and the prompt contains the Makefile command-mapping guidance.

## Ticket

Closes #60


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `kit init` now creates a starter `Makefile` with a safe `help` command.
  * Initialization guidance now includes populating the Makefile with project-specific commands.
  * `kit init --refresh` creates a missing Makefile when requested.

* **Bug Fixes**
  * Existing Makefiles are preserved during initialization and forced refreshes instead of being overwritten.

* **Documentation**
  * Updated command documentation to describe Makefile starter scaffolding and refresh behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->